### PR TITLE
Fix every gem version in the Gemfiles

### DIFF
--- a/son-gtkapi/Gemfile
+++ b/son-gtkapi/Gemfile
@@ -1,31 +1,29 @@
 source 'https://rubygems.org'
 
-#LANG='en_US.UTF-8'
-#LC_ALL='en_US.UTF-8'
-
-gem 'rake'
-gem 'sinatra', '~> 1.4.3', require: 'sinatra/base'
-gem 'sinatra-contrib', '~> 1.4.1', require: false
-gem 'pry'
-gem 'puma'
-gem 'rest-client'
-gem 'rack-parser', require: 'rack/parser'
-gem 'sinatra-cross_origin'
-gem 'ci_reporter_rspec'
-gem 'rubyzip', '>= 1.0.0'
-gem 'foreman'
-gem 'addressable'
-gem 'rubocop'
-gem 'rubocop-checkstyle_formatter', require: false
-gem 'sinatra-logger'
+gem 'rake', '11.2.2'
+gem 'sinatra', '1.4.6', require: 'sinatra/base'
+gem 'sinatra-contrib', '1.4.6', require: false
+gem 'pry', '0.10.4'
+gem 'puma', '3.6.0'
+gem 'rest-client', '2.0.0'
+gem 'rack-parser', '0.7.0', require: 'rack/parser'
+gem 'sinatra-cross_origin', '0.3.2'
+gem 'ci_reporter_rspec', '1.0.0'
+gem 'rubyzip', '1.2.0'
+gem 'foreman', '0.82.0'
+gem 'addressable', '2.4.0'
+gem 'rubocop', '0.42.0'
+gem 'rubocop-checkstyle_formatter', '0.3.0', require: false
+gem 'sinatra-logger', '0.3.1'
 
 group :test do
-  gem 'webmock'
-  gem 'rspec'
-  gem 'rack-test'
-  gem 'rspec-its'
+  gem 'webmock', '2.1.0'
+  gem 'rspec', '3.5.0'
+  gem 'rack-test', '0.6.3'
+  gem 'rspec-its', '1.2.0'
 end
 
 group :test, :development do
-  gem 'capybara'
+  gem 'capybara', '2.8.1'
 end
+

--- a/son-gtkapi/Gemfile
+++ b/son-gtkapi/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'rake', '11.2.2'
-gem 'sinatra', '1.4.6', require: 'sinatra/base'
-gem 'sinatra-contrib', '1.4.6', require: false
+gem 'sinatra', '1.4.7', require: 'sinatra/base'
+gem 'sinatra-contrib', '1.4.7', require: false
 gem 'pry', '0.10.4'
 gem 'puma', '3.6.0'
 gem 'rest-client', '2.0.0'
@@ -14,7 +14,7 @@ gem 'foreman', '0.82.0'
 gem 'addressable', '2.4.0'
 gem 'rubocop', '0.42.0'
 gem 'rubocop-checkstyle_formatter', '0.3.0', require: false
-gem 'sinatra-logger', '0.3.1'
+gem 'sinatra-logger', '0.1.1'
 
 group :test do
   gem 'webmock', '2.1.0'
@@ -24,6 +24,6 @@ group :test do
 end
 
 group :test, :development do
-  gem 'capybara', '2.8.1'
+  gem 'capybara', '2.7.1'
 end
 

--- a/son-gtkfnct/Gemfile
+++ b/son-gtkfnct/Gemfile
@@ -1,31 +1,29 @@
 source 'https://rubygems.org'
 
-gem 'rake'
-gem 'sinatra', '~> 1.4.3', require: 'sinatra/base'
-gem 'sinatra-contrib', '~> 1.4.1', require: false
-gem 'pry'
-gem 'puma'
-gem 'rest-client'
-gem 'rack-parser', require: 'rack/parser'
-gem 'sinatra-cross_origin'
-gem 'ci_reporter_rspec'
-gem 'rubyzip', '>= 1.0.0'
-gem 'foreman'
-gem 'addressable'
-gem 'rubocop'
-gem 'rubocop-checkstyle_formatter', require: false
-gem 'sinatra-logger'
-gem 'sinatra-active-model-serializers', '~> 0.2.0'
+gem 'rake', '11.2.2'
+gem 'sinatra', '1.4.6', require: 'sinatra/base'
+gem 'sinatra-contrib', '1.4.6', require: false
+gem 'pry', '0.10.4'
+gem 'puma', '3.6.0'
+gem 'rest-client', '2.0.0'
+gem 'rack-parser', '0.7.0', require: 'rack/parser'
+gem 'sinatra-cross_origin', '0.3.2'
+gem 'ci_reporter_rspec', '1.0.0'
+gem 'rubyzip', '1.2.0'
+gem 'foreman', '0.82.0'
+gem 'addressable', '2.4.0'
+gem 'rubocop', '0.42.0'
+gem 'rubocop-checkstyle_formatter', '0.3.0', require: false
+gem 'sinatra-logger', '0.3.1'
+gem 'sinatra-active-model-serializers', '0.2.0'
 
 group :test do
-  gem 'webmock'
-  gem 'rspec'
-  gem 'rspec-mocks'
-  gem 'rack-test', require: 'rack/test'
-  gem 'rspec-its'
+  gem 'webmock', '2.1.0'
+  gem 'rspec', '3.5.0'
+  gem 'rack-test', '0.6.3'
+  gem 'rspec-its', '1.2.0'
 end
 
 group :test, :development do
-  gem 'capybara'
+  gem 'capybara', '2.8.1'
 end
-

--- a/son-gtkfnct/Gemfile
+++ b/son-gtkfnct/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rake', '11.2.2'
-gem 'sinatra', '1.4.6', require: 'sinatra/base'
+gem 'sinatra', '1.4.7', require: 'sinatra/base'
 gem 'sinatra-contrib', '1.4.6', require: false
 gem 'pry', '0.10.4'
 gem 'puma', '3.6.0'
@@ -14,8 +14,8 @@ gem 'foreman', '0.82.0'
 gem 'addressable', '2.4.0'
 gem 'rubocop', '0.42.0'
 gem 'rubocop-checkstyle_formatter', '0.3.0', require: false
-gem 'sinatra-logger', '0.3.1'
-gem 'sinatra-active-model-serializers', '0.2.0'
+gem 'sinatra-logger', '0.1.1'
+gem 'sinatra-active-model-serializers', '0.2.2'
 
 group :test do
   gem 'webmock', '2.1.0'
@@ -25,5 +25,5 @@ group :test do
 end
 
 group :test, :development do
-  gem 'capybara', '2.8.1'
+  gem 'capybara', '2.7.1'
 end

--- a/son-gtkpkg/Gemfile
+++ b/son-gtkpkg/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'rake', '11.2.2'
-gem 'sinatra', '1.4.6', require: 'sinatra/base'
-gem 'sinatra-contrib', '1.4.6', require: false
+gem 'sinatra', '1.4.7', require: 'sinatra/base'
+gem 'sinatra-contrib', '1.4.7', require: false
 gem 'pry', '0.10.4'
 gem 'puma', '3.6.0'
 gem 'rest-client', '2.0.0'
@@ -13,7 +13,7 @@ gem 'rubyzip', '1.2.0'
 gem 'foreman', '0.82.0'
 gem 'rubocop', '0.42.0'
 gem 'rubocop-checkstyle_formatter', '0.3.0', require: false
-gem 'sinatra-logger', '0.3.1'
+gem 'sinatra-logger', '0.1.1'
 
 group :test do
   gem 'webmock', '2.1.0'
@@ -23,5 +23,6 @@ group :test do
 end
 
 group :test, :development do
-  gem 'capybara', '2.8.1'
+  gem 'capybara', '2.7.1'
 end
+

--- a/son-gtkpkg/Gemfile
+++ b/son-gtkpkg/Gemfile
@@ -1,30 +1,27 @@
 source 'https://rubygems.org'
 
-#LANG='en_US.UTF-8'
-#LC_ALL='en_US.UTF-8'
-
-gem 'rake'
-gem 'sinatra', '~> 1.4.3', require: 'sinatra/base'
-gem 'sinatra-contrib', '~> 1.4.1', require: false
-gem 'pry'
-gem 'puma'
-gem 'rest-client'
-gem 'rack-parser', require: 'rack/parser'
-gem 'sinatra-cross_origin'
-gem 'sinatra-logger'
-gem 'ci_reporter_rspec'
-gem 'rubyzip', '>= 1.0.0'
-gem 'foreman'
-gem 'rubocop'
-gem 'rubocop-checkstyle_formatter', require: false
+gem 'rake', '11.2.2'
+gem 'sinatra', '1.4.6', require: 'sinatra/base'
+gem 'sinatra-contrib', '1.4.6', require: false
+gem 'pry', '0.10.4'
+gem 'puma', '3.6.0'
+gem 'rest-client', '2.0.0'
+gem 'rack-parser', '0.7.0', require: 'rack/parser'
+gem 'sinatra-cross_origin', '0.3.2'
+gem 'ci_reporter_rspec', '1.0.0'
+gem 'rubyzip', '1.2.0'
+gem 'foreman', '0.82.0'
+gem 'rubocop', '0.42.0'
+gem 'rubocop-checkstyle_formatter', '0.3.0', require: false
+gem 'sinatra-logger', '0.3.1'
 
 group :test do
-  gem 'webmock'
-  gem 'rspec'
-  gem 'rack-test'
-  gem 'rspec-its'
+  gem 'webmock', '2.1.0'
+  gem 'rspec', '3.5.0'
+  gem 'rack-test', '0.6.3'
+  gem 'rspec-its', '1.2.0'
 end
 
 group :test, :development do
-  gem 'capybara'
+  gem 'capybara', '2.8.1'
 end

--- a/son-gtkrec/Gemfile
+++ b/son-gtkrec/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'rake', '11.2.2'
-gem 'sinatra', '1.4.6', require: 'sinatra/base'
-gem 'sinatra-contrib', '1.4.6', require: false
+gem 'sinatra', '1.4.7', require: 'sinatra/base'
+gem 'sinatra-contrib', '1.4.7', require: false
 gem 'pry', '0.10.4'
 gem 'puma', '3.6.0'
 gem 'rest-client', '2.0.0'
@@ -15,7 +15,7 @@ gem 'addressable', '2.4.0'
 gem 'bunny', '2.5.1'
 gem 'rubocop', '0.42.0'
 gem 'rubocop-checkstyle_formatter', '0.3.0', require: false
-gem 'sinatra-logger', '0.3.1'
+gem 'sinatra-logger', '0.1.1'
 
 group :test do
   gem 'webmock', '2.1.0'
@@ -25,5 +25,5 @@ group :test do
 end
 
 group :test, :development do
-  gem 'capybara', '2.8.1'
+  gem 'capybara', '2.7.1'
 end

--- a/son-gtkrec/Gemfile
+++ b/son-gtkrec/Gemfile
@@ -1,29 +1,29 @@
 source 'https://rubygems.org'
 
-gem 'rake'
-gem 'sinatra', '~> 1.4.3', require: 'sinatra/base'
-gem 'sinatra-contrib', '~> 1.4.1', require: false
-gem 'pry'
-gem 'puma'
-gem 'rest-client'
-gem 'rack-parser', require: 'rack/parser'
-gem 'sinatra-cross_origin'
-gem 'ci_reporter_rspec'
-gem 'rubyzip', '>= 1.0.0'
-gem 'foreman'
-gem 'addressable'
-gem 'bunny', '>= 2.3.0'
-gem 'rubocop'
-gem 'rubocop-checkstyle_formatter', require: false
-gem 'sinatra-logger'
+gem 'rake', '11.2.2'
+gem 'sinatra', '1.4.6', require: 'sinatra/base'
+gem 'sinatra-contrib', '1.4.6', require: false
+gem 'pry', '0.10.4'
+gem 'puma', '3.6.0'
+gem 'rest-client', '2.0.0'
+gem 'rack-parser', '0.7.0', require: 'rack/parser'
+gem 'sinatra-cross_origin', '0.3.2'
+gem 'ci_reporter_rspec', '1.0.0'
+gem 'rubyzip', '1.2.0'
+gem 'foreman', '0.82.0'
+gem 'addressable', '2.4.0'
+gem 'bunny', '2.5.1'
+gem 'rubocop', '0.42.0'
+gem 'rubocop-checkstyle_formatter', '0.3.0', require: false
+gem 'sinatra-logger', '0.3.1'
 
 group :test do
-  gem 'rspec'
-  gem 'rspec-mocks'
-  gem 'rack-test', require: 'rack/test'
-  gem 'rspec-its'
+  gem 'webmock', '2.1.0'
+  gem 'rspec', '3.5.0'
+  gem 'rack-test', '0.6.3'
+  gem 'rspec-its', '1.2.0'
 end
 
 group :test, :development do
-  gem 'capybara'
+  gem 'capybara', '2.8.1'
 end

--- a/son-gtksrv/Gemfile
+++ b/son-gtksrv/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'rake', '11.2.2'
-gem 'sinatra', '1.4.6', require: 'sinatra/base'
-gem 'sinatra-contrib', '1.4.6', require: false
+gem 'sinatra', '1.4.7', require: 'sinatra/base'
+gem 'sinatra-contrib', '1.4.7', require: false
 gem 'pry', '0.10.4'
 gem 'puma', '3.6.0'
 gem 'rest-client', '2.0.0'
@@ -18,8 +18,8 @@ gem 'rubocop-checkstyle_formatter', '0.2.0', require: false
 gem 'pg', '0.18.4'
 gem 'activerecord', '4.2.5.1'
 gem 'sinatra-activerecord', '2.0.4'
-gem 'sinatra-logger', '0.3.1'
-gem 'sinatra-active-model-serializers', '0.2.0'
+gem 'sinatra-logger', '0.1.1'
+gem 'sinatra-active-model-serializers', '0.2.2'
 
 group :test do
   gem 'webmock', '2.1.0'
@@ -30,5 +30,5 @@ group :test do
 end
 
 group :test, :development do
-  gem 'capybara', '2.8.0'
+  gem 'capybara', '2.7.1'
 end

--- a/son-gtksrv/Gemfile
+++ b/son-gtksrv/Gemfile
@@ -1,34 +1,34 @@
 source 'https://rubygems.org'
 
-gem 'rake'
-gem 'sinatra', '~> 1.4.3', require: 'sinatra/base'
-gem 'sinatra-contrib', '~> 1.4.1', require: false
-gem 'pry'
-gem 'puma'
-gem 'rest-client'
-gem 'rack-parser', require: 'rack/parser'
-gem 'sinatra-cross_origin'
-gem 'ci_reporter_rspec'
-gem 'rubyzip', '>= 1.0.0'
-gem 'foreman'
-gem 'addressable'
-gem 'bunny', '>= 2.3.0'
-gem 'rubocop'
-gem 'rubocop-checkstyle_formatter', require: false
-gem 'pg'
+gem 'rake', '11.2.2'
+gem 'sinatra', '1.4.6', require: 'sinatra/base'
+gem 'sinatra-contrib', '1.4.6', require: false
+gem 'pry', '0.10.4'
+gem 'puma', '3.6.0'
+gem 'rest-client', '2.0.0'
+gem 'rack-parser', '0.7.0', require: 'rack/parser'
+gem 'sinatra-cross_origin', '0.3.2'
+gem 'ci_reporter_rspec', '1.0.0'
+gem 'rubyzip', '1.2.0'
+gem 'foreman', '0.82.0'
+gem 'addressable', '2.4.0'
+gem 'bunny', '2.5.1'
+gem 'rubocop', '0.42.0'
+gem 'rubocop-checkstyle_formatter', '0.2.0', require: false
+gem 'pg', '0.18.4'
 gem 'activerecord', '4.2.5.1'
 gem 'sinatra-activerecord', '2.0.4'
-gem 'sinatra-logger'
+gem 'sinatra-logger', '0.3.1'
 gem 'sinatra-active-model-serializers', '0.2.0'
 
 group :test do
-  gem 'webmock'
-  gem 'rspec'
-  gem 'rspec-mocks'
+  gem 'webmock', '2.1.0'
+  gem 'rspec', '3.5.0'
+  gem 'rspec-mocks', '3.5.0'
   gem 'rack-test', require: 'rack/test'
-  gem 'rspec-its'
+  gem 'rspec-its', '1.2.0'
 end
 
 group :test, :development do
-  gem 'capybara'
+  gem 'capybara', '2.8.0'
 end

--- a/son-gtkvim/Gemfile
+++ b/son-gtkvim/Gemfile
@@ -1,34 +1,33 @@
 source 'https://rubygems.org'
 
-gem 'rake'
-gem 'sinatra', '~> 1.4.3', require: 'sinatra/base'
-gem 'sinatra-contrib', '~> 1.4.1', require: false
-gem 'pry'
-gem 'puma'
-gem 'rest-client'
-gem 'rack-parser', require: 'rack/parser'
-gem 'sinatra-cross_origin'
-gem 'ci_reporter_rspec'
-gem 'rubyzip', '>= 1.0.0'
-gem 'foreman'
-gem 'addressable'
-gem 'bunny', '>= 2.3.0'
-gem 'rubocop'
-gem 'rubocop-checkstyle_formatter', require: false
-gem 'pg'
+gem 'rake', '11.2.2'
+gem 'sinatra', '1.4.6', require: 'sinatra/base'
+gem 'sinatra-contrib', '1.4.6', require: false
+gem 'pry', '0.10.4'
+gem 'puma', '3.6.0'
+gem 'rest-client', '2.0.0'
+gem 'rack-parser', '0.7.0', require: 'rack/parser'
+gem 'sinatra-cross_origin', '0.3.2'
+gem 'ci_reporter_rspec', '1.0.0'
+gem 'rubyzip', '1.2.0'
+gem 'foreman', '0.82.0'
+gem 'addressable', '2.4.0'
+gem 'rubocop', '0.42.0'
+gem 'rubocop-checkstyle_formatter', '0.3.0', require: false
 gem 'activerecord', '4.2.5.1'
 gem 'sinatra-activerecord', '2.0.4'
-gem 'sinatra-logger'
+gem 'sinatra-logger', '0.3.1'
 gem 'sinatra-active-model-serializers', '0.2.0'
+gem 'bunny', '2.5.1'
+gem 'pg', '0.18.4'
 
 group :test do
-  gem 'webmock'
-  gem 'rspec'
-  gem 'rspec-mocks'
-  gem 'rack-test', require: 'rack/test'
-  gem 'rspec-its'
+  gem 'webmock', '2.1.0'
+  gem 'rspec', '3.5.0'
+  gem 'rack-test', '0.6.3'
+  gem 'rspec-its', '1.2.0'
 end
 
 group :test, :development do
-  gem 'capybara'
+  gem 'capybara', '2.8.1'
 end

--- a/son-gtkvim/Gemfile
+++ b/son-gtkvim/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'rake', '11.2.2'
-gem 'sinatra', '1.4.6', require: 'sinatra/base'
-gem 'sinatra-contrib', '1.4.6', require: false
+gem 'sinatra', '1.4.7', require: 'sinatra/base'
+gem 'sinatra-contrib', '1.4.7', require: false
 gem 'pry', '0.10.4'
 gem 'puma', '3.6.0'
 gem 'rest-client', '2.0.0'
@@ -16,8 +16,8 @@ gem 'rubocop', '0.42.0'
 gem 'rubocop-checkstyle_formatter', '0.3.0', require: false
 gem 'activerecord', '4.2.5.1'
 gem 'sinatra-activerecord', '2.0.4'
-gem 'sinatra-logger', '0.3.1'
-gem 'sinatra-active-model-serializers', '0.2.0'
+gem 'sinatra-logger', '0.1.1'
+gem 'sinatra-active-model-serializers', '0.2.2'
 gem 'bunny', '2.5.1'
 gem 'pg', '0.18.4'
 
@@ -29,5 +29,5 @@ group :test do
 end
 
 group :test, :development do
-  gem 'capybara', '2.8.1'
+  gem 'capybara', '2.7.1'
 end


### PR DESCRIPTION
Having just the mention of the gem name in the Gemfile implies downloading always the
most up to date version, which caused problems when we launched 0.9.