### PR TITLE
Fix MQServer queue name

### DIFF
--- a/son-gtksrv/models/mq_server.rb
+++ b/son-gtksrv/models/mq_server.rb
@@ -34,7 +34,7 @@ require 'json'
 class MQServer
   attr_accessor :url
   
-  CREATE_QUEUE = 'service.instances.instances'
+  CREATE_QUEUE = 'service.instances.create'
   
   def initialize(url,logger)
     @url = url


### PR DESCRIPTION
Was 'service.instances.instances' and is now 'service.instances.create'