### PR TITLE
Improve error message when no service is available

### DIFF
--- a/son-gtkapi/routes/service.rb
+++ b/son-gtkapi/routes/service.rb
@@ -45,7 +45,7 @@ class GtkApi < Sinatra::Base
       halt 200, services.to_json if services
     else
       logger.debug "GtkApi: leaving GET /services?#{uri.query} with \"No services with #{uri.query} were found\""
-      halt 404, "No services with #{uri.query} were found"
+      halt 404, "No services with params=#{params} were found"
     end
   end
   

--- a/son-gtkvim/routes/request.rb
+++ b/son-gtkvim/routes/request.rb
@@ -74,7 +74,6 @@ class GtkVim < Sinatra::Base
   end
   
   # Creates a new VIM
-  
   post '/vim/?' do
     original_body = request.body.read
     logger.info "GtkVim: entered POST /vim with original_body=#{original_body}"
@@ -102,6 +101,4 @@ class GtkVim < Sinatra::Base
       halt 500, 'Internal server error'
     end
   end
-
- 
 end


### PR DESCRIPTION
When no parameters were passed to /services and no service existed, 404 wa returned with an awkward message