### PR TITLE
Refactors the usage of logger

### DIFF
--- a/son-gtkapi/config/services.yml.erb
+++ b/son-gtkapi/config/services.yml.erb
@@ -33,7 +33,7 @@ development: &common_settings
   recmgmt: <%= ENV['RECORD_MANAGEMENT_URL'] %>
   licmgmt: <%= ENV['LICENCE_MANAGEMENT_URL'] %>
   kpimgmt: <%= ENV['KPI_MANAGEMENT_URL'] %>
-  logger_level: <%= (ENV['LOGGER_LEVEL'] ||= 'debug').to_sym %> # can be :debug, :fatal, :error, :warn, or :info
+  logger_level: <%= ENV['LOGGER_LEVEL'] ||= 'debug' %> # can be debug, fatal, error, warn, or info
 
 test:
   <<: *common_settings

--- a/son-gtkapi/models/function_manager_service.rb
+++ b/son-gtkapi/models/function_manager_service.rb
@@ -29,32 +29,22 @@ require './models/manager_service.rb'
 
 class FunctionManagerService < ManagerService
     
-  # We're not yet using this: it allows for multiple implementations, such as Fakes (for testing)
-  attr_reader :url, :logger
-  
   JSON_HEADERS = { 'Accept'=> 'application/json', 'Content-Type'=>'application/json'}
   LOG_MESSAGE = 'GtkApi::' + self.name
   
-  def self.config(url:, logger:)
-    method = LOG_MESSAGE + "#config(url=#{url}, logger=#{logger})"
+  def self.config(url:)
+    method = LOG_MESSAGE + "#config(url=#{url})"
     raise ArgumentError.new('FunctionManagerService can not be configured with nil url') if url.nil?
     raise ArgumentError.new('FunctionManagerService can not be configured with empty url') if url.empty?
-    raise ArgumentError.new('FunctionManagerService can not be configured with nil logger') if logger.nil?
     @@url = url
-    @@logger = logger
-    @@logger.debug(method) {'entered'}
-  end
-
-  def self.url
-    @@logger.debug(LOG_MESSAGE + "#url") {'@@url='+@@url}
-    @@url
+    GtkApi.logger.debug(method) {'entered'}
   end
 
   def self.find_function_by_uuid(uuid)
-    find(url: @@url + '/functions/' + uuid, log_message: LOG_MESSAGE + "##{__method__}(#{uuid})", logger: @@logger)
+    find(url: @@url + '/functions/' + uuid, log_message: LOG_MESSAGE + "##{__method__}(#{uuid})")
   end
   
   def self.find_functions(params)
-    find(url: @@url + '/functions', params: params, log_message: LOG_MESSAGE + "##{__method__}(#{params})", logger: @@logger)
+    find(url: @@url + '/functions', params: params, log_message: LOG_MESSAGE + "##{__method__}(#{params})")
   end
 end

--- a/son-gtkapi/models/kpi_manager_service.rb
+++ b/son-gtkapi/models/kpi_manager_service.rb
@@ -32,34 +32,27 @@ class KpiManagerService < ManagerService
   JSON_HEADERS = { 'Accept'=> 'application/json', 'Content-Type'=>'application/json'}
   LOG_MESSAGE = 'GtkApi::' + self.name
   
-  def self.config(url:, logger:)
-    method = LOG_MESSAGE + "##{__method__}(url=#{url}, logger=#{logger})"
+  def self.config(url:)
+    method = LOG_MESSAGE + "##{__method__}(url=#{url})"
     raise ArgumentError.new('KpiManagerService can not be configured with nil url') if url.nil?
     raise ArgumentError.new('KpiManagerService can not be configured with empty url') if url.empty?
-    raise ArgumentError.new('KpiManagerService can not be configured with nil logger') if logger.nil?
     @@url = url
-    @@logger = logger
-    @@logger.debug(method) {'entered'}
-  end
-
-  def self.url
-    @@logger.debug(LOG_MESSAGE + "#url") {'@@url='+@@url}
-    @@url
+    GtkApi.logger.debug(method) {'entered'}
   end
 
   def self.increase_metric(params)
     method = LOG_MESSAGE + "##{__method__}(#{params})"
-    @@logger.debug(method) {"entered"}
+    GtkApi.logger.debug(method) {"entered"}
     
     begin
-      @@logger.debug(method) {"@@url = "+@@url}
+      GtkApi.logger.debug(method) {"@@url = "+@@url}
       #response = RestClient.post(@url+'/kpi', params.to_json, content_type: :json, accept: :json) 
       response = postCurb(url: @@url+'/kpi', body: params, logger: @@logger)
-      @logger.debug(method) {"response="+response}
+      GtkApi.logger.debug(method) {"response="+response}
       response
     rescue => e
-      @@logger.error(method) {"Error during processing: #{$!}"}
-      @@logger.error(method) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"}
+      GtkApi.logger.error(method) {"Error during processing: #{$!}"}
+      GtkApi.logger.error(method) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"}
       nil 
     end      
   end

--- a/son-gtkapi/models/manager_service.rb
+++ b/son-gtkapi/models/manager_service.rb
@@ -38,66 +38,66 @@ class ManagerService
     @logger.debug(method) {'entered'}
   end
   
-  def self.getCurb(url:, params: {}, headers: {}, logger: nil)
+  def self.getCurb(url:, params: {}, headers: {})
     log_message=LOG_MESSAGE+"##{__method__}"
-    logger.debug(log_message) {"entered with url=#{url}, params=#{params}, headers=#{headers}, logger=#{logger.inspect}"} if logger
+    GtkApi.logger.debug(log_message) {"entered with url=#{url}, params=#{params}, headers=#{headers}"}
     complete_url = params.empty? ? url : url + '?' + Curl::postalize(params)
-    logger.debug(log_message) {"complete_url=#{complete_url}"} if logger
+    GtkApi.logger.debug(log_message) {"complete_url=#{complete_url}"} 
     res=Curl.get(complete_url) do |req|
       headers.each do |h|
-        logger.debug(log_message) {"header[#{h[0]}]: #{h[1]}"} if logger
+        GtkApi.logger.debug(log_message) {"header[#{h[0]}]: #{h[1]}"}
         req.headers[h[0]] = h[1]
       end
     end
-    logger.debug(log_message) {"header_str=#{res.header_str}"} if logger
-    logger.debug(log_message) {"response body=#{res.body}"} if logger
+    GtkApi.logger.debug(log_message) {"header_str=#{res.header_str}"}
+    GtkApi.logger.debug(log_message) {"response body=#{res.body}"}
     count = get_record_count_from_response_headers(res.header_str)
     status = get_status_from_response_headers(res.header_str)
     case status
     when 200..202
       begin
         parsed_response = res.body.empty? ? {} : JSON.parse(res.body, symbolize_names: true)
-        logger.debug(log_message) {"parsed_response=#{parsed_response}"} if logger
+        GtkApi.logger.debug(log_message) {"parsed_response=#{parsed_response}"}
         {status: status, count: count, items: parsed_response, message: "OK"}
       rescue => e
-        logger.error(log_message) {"Error during processing: #{$!}"} if logger
-        logger.error(log_message) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"} if logger
+        GtkApi.logger.error(log_message) {"Error during processing: #{$!}"}
+        GtkApi.logger.error(log_message) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"}
         {status: nil, count: nil, items: nil, message: "Error processing #{$!}: \n\t#{e.backtrace.join("\n\t")}"}
       end
     when 400
     when 404
-      logger.debug(log_message) {"Records not found for url=#{url}, params=#{params}, headers=#{headers}, logger=#{logger.inspect}"} if logger
+      GtkApi.logger.debug(log_message) {"Records not found for url=#{url}, params=#{params}, headers=#{headers}"}
       {status: status, count: 0, items: [], message: "Not Found"}
     else
-      logger.debug(log_message) {"Unexpected status code received: #{status}"}
+      GtkApi.logger.debug(log_message) {"Unexpected status code received: #{status}"}
       {status: status, count: nil, items: nil, message: "Status #{status} unprocessable"}
     end
   end
   
-  def self.postCurb(url:, body:, headers: {}, logger: nil)
+  def self.postCurb(url:, body:, headers: {})
     log_message=LOG_MESSAGE+"##{__method__}"
-    logger.debug(log_message) {"entered with url=#{url}, body=#{body}, logger=#{logger.inspect}"} if logger
+    GtkApi.logger.debug(log_message) {"entered with url=#{url}, body=#{body}"}
     res=Curl.post(url, body) do |req|
       if headers.empty?
         req.headers['Content-type'] = req.headers['Accept'] = 'application/json'
       else
         headers.each do |h|
-          logger.debug(log_message) {"header[#{h[0]}]: #{h[1]}"} if logger
+          GtkApi.logger.debug(log_message) {"header[#{h[0]}]: #{h[1]}"}
           req.headers[h[0]] = h[1]
         end
       end
     end
-    logger.debug(log_message) {"response body=#{res.body}"} if logger
+    GtkApi.logger.debug(log_message) {"response body=#{res.body}"}
     status = get_status_from_response_headers(res.header_str)
     case status
     when 200..202
       begin
         parsed_response = JSON.parse(res.body, symbolize_names: true)
-        logger.debug(log_message) {"parsed_response=#{parsed_response}"} if logger
+        GtkApi.logger.debug(log_message) {"parsed_response=#{parsed_response}"}
         {status: status, count: 1, items: parsed_response, message: "OK"}
       rescue => e
-        logger.error(log_message) {"Error during processing: #{$!}"} if logger
-        logger.error(log_message) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"} if logger
+        GtkApi.logger.error(log_message) {"Error during processing: #{$!}"} 
+        GtkApi.logger.error(log_message) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"}
         {status: nil, count: nil, items: nil, message: "Error processing #{$!}: \n\t#{e.backtrace.join("\n\t")}"}
       end
     else
@@ -141,28 +141,28 @@ class ManagerService
   end
   
   def self.get_log(url:, log_message:'', logger: nil)
-    logger.debug(log_message) {'entered'} if logger
+    GtkApi.logger.debug(log_message) {'entered'}
 
     response=Curl.get( url) do |req|
       req.headers['Content-Type'] = 'text/plain; charset=utf8'
       req.headers['Location'] = '/'
     end    
     
-    logger.debug(log_message) {'status=' + response.response_code.to_s} if logger
+    GtkApi.logger.debug(log_message) {'status=' + response.response_code.to_s}
     case response.response_code
       when 200
         response.body
       else
-        logger.error(log_message) {"Error during processing: #{$!}"} if logger
-        logger.error(log_message) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"} if logger
+        GtkApi.logger.error(log_message) {"Error during processing: #{$!}"}
+        GtkApi.logger.error(log_message) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"}
         nil
       end
   end
 
-  def self.find(url:, params: {}, headers: JSON_HEADERS, log_message:'', logger: nil)
-    logger.debug(log_message) {'entered'}
-    response = getCurb(url: url, params: params, headers: headers, logger: logger)
-    logger.debug(log_message) {"response=#{response}"} if logger
+  def self.find(url:, params: {}, headers: JSON_HEADERS, log_message:'')
+    GtkApi.logger.debug(log_message) {'entered'}
+    response = getCurb(url: url, params: params, headers: headers)
+    GtkApi.logger.debug(log_message) {"response=#{response}"}
     response
   end
   

--- a/son-gtkapi/models/package_manager_service.rb
+++ b/son-gtkapi/models/package_manager_service.rb
@@ -34,28 +34,26 @@ class PackageManagerService < ManagerService
   
   LOG_MESSAGE = 'GtkApi::' + self.name
   
-  def self.config(url:, logger:)
-    method = LOG_MESSAGE + "#config(url=#{url}, logger=#{logger})"
+  def self.config(url:)
+    method = LOG_MESSAGE + "#config(url=#{url})"
     raise ArgumentError.new('PackageManagerService can not be configured with nil url') if url.nil?
     raise ArgumentError.new('PackageManagerService can not be configured with empty url') if url.empty?
-    raise ArgumentError.new('PackageManagerService can not be configured with nil logger') if logger.nil?
     @@url = url
-    @@logger = logger
-    @@logger.debug(method) {'entered'}
+    GtkApi.logger.debug(method) {'entered'}
   end
 
   def self.create(params)
     method = LOG_MESSAGE + ".create"
-    @@logger.debug(method) {'entered'}
+    GtkApi.logger.debug(method) {'entered'}
 
     tmpfile = params[:package][:tempfile]
     uri = @@url+'/packages'
-    @@logger.debug(method) {"POSTing to "+uri+ "#{params}"}
+    GtkApi.logger.debug(method) {"POSTing to "+uri+ "#{params}"}
     begin
       #response = RestClient.post(uri, params)
       # from http://www.rubydoc.info/gems/rest-client/1.6.7/frames#Result_handling
       RestClient.post(uri, params){ |response, request, result, &block|
-        @@logger.debug(method) {"response=#{response.inspect}"}
+        GtkApi.logger.debug(method) {"response=#{response.inspect}"}
         case response.code
         when 201
           { status: 201, count: 1, data: JSON.parse(response.body), message: 'Created'}
@@ -68,20 +66,20 @@ class PackageManagerService < ManagerService
         end
       }
     rescue  => e #RestClient::Conflict
-      @@logger.error(method) {"Error during processing: #{$!}"}
-      @@logger.error(method) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"}
+      GtkApi.logger.error(method) {"Error during processing: #{$!}"}
+      GtkApi.logger.error(method) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"}
       { status: 500, count: 0, data: {}, message: e.backtrace.join("\n\t")}
     end    
   end
 
   def self.find_by_uuid(uuid)
     method = LOG_MESSAGE + ".find_by_uuid(#{uuid})"
-    @@logger.debug(method) {'entered'}
+    GtkApi.logger.debug(method) {'entered'}
     headers = { 'Accept'=> '*/*', 'Content-Type'=>'application/json'}
     headers[:params] = uuid
     begin
       response = RestClient.get(@@url+"/packages/#{uuid}", headers)
-      @@logger.debug(method) {"response #{response}"}
+      GtkApi.logger.debug(method) {"response #{response}"}
       response
     rescue => e
       e.to_json
@@ -90,22 +88,17 @@ class PackageManagerService < ManagerService
   
   def self.find(params)
     method = LOG_MESSAGE + ".find(#{params})"
-    @@logger.debug(method) {'entered'}
+    GtkApi.logger.debug(method) {'entered'}
     headers = { 'Accept'=> 'application/json', 'Content-Type'=>'application/json'}
     headers[:params] = params
     begin
       response = RestClient.get(@@url+'/packages', headers)
-      @@logger.debug(method) {"response #{response}"}
+      GtkApi.logger.debug(method) {"response #{response}"}
       response
     rescue => e
-      @@logger.error(method) {"Error during processing: #{$!}"}
-      @@logger.error(method) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"}
+      GtkApi.logger.error(method) {"Error during processing: #{$!}"}
+      GtkApi.logger.error(method) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"}
       nil
     end
-  end
-    
-  def self.url
-    @@logger.debug(LOG_MESSAGE + "#url") {'@@url='+@@url}
-    @@url
   end
 end

--- a/son-gtkapi/models/record_manager_service.rb
+++ b/son-gtkapi/models/record_manager_service.rb
@@ -32,29 +32,22 @@ class RecordManagerService < ManagerService
   JSON_HEADERS = { 'Accept'=> 'application/json', 'Content-Type'=>'application/json'}
   LOG_MESSAGE = 'GtkApi::' + self.name
   
-  def self.config(url:, logger:)
-    method = LOG_MESSAGE + "##{__method__}(url=#{url}, logger=#{logger})"
+  def self.config(url:)
+    method = LOG_MESSAGE + "##{__method__}(url=#{url})"
     raise ArgumentError.new('RecordManagerService can not be configured with nil url') if url.nil?
     raise ArgumentError.new('RecordManagerService can not be configured with empty url') if url.empty?
-    raise ArgumentError.new('RecordManagerService can not be configured with nil logger') if logger.nil?
     @@url = url
-    @@logger = logger
-    @@logger.debug(method) {'entered'}
-  end
-  
-  def self.url
-    @@logger.debug(LOG_MESSAGE + "#url") {'@@url='+@@url}
-    @@url
+    GtkApi.logger.debug(method) {'entered'}
   end
   
   def self.find_records(params)
     #params['kind']
     kind = params.delete('kind')
-    records= find(url: @@url + '/' + kind, params: params, log_message: LOG_MESSAGE + "##{__method__}(#{params})", logger: @@logger)
+    records= find(url: @@url + '/' + kind, params: params, log_message: LOG_MESSAGE + "##{__method__}(#{params})")
     vectorize_hash records
   end
   
   def self.find_record_by_uuid(uuid)
-    find(url: @@url + '/' + kind + '/' + uuid, log_message: LOG_MESSAGE + "##{__method__}(#{uuid})", logger: @@logger) #+ '/records/' 
+    find(url: @@url + '/' + kind + '/' + uuid, log_message: LOG_MESSAGE + "##{__method__}(#{uuid})") #+ '/records/' 
   end
 end

--- a/son-gtkapi/models/service_manager_service.rb
+++ b/son-gtkapi/models/service_manager_service.rb
@@ -32,74 +32,72 @@ class ServiceManagerService < ManagerService
   JSON_HEADERS = { 'Accept'=> 'application/json', 'Content-Type'=>'application/json'}
   LOG_MESSAGE = 'GtkApi::' + self.name
     
-  def self.config(url:, logger:)
-    method = LOG_MESSAGE + "#config(url=#{url}, logger=#{logger})"
+  def self.config(url:)
+    method = LOG_MESSAGE + "#config"
     raise ArgumentError.new('ServiceManagerService can not be configured with nil url') if url.nil?
     raise ArgumentError.new('ServiceManagerService can not be configured with empty url') if url.empty?
-    raise ArgumentError.new('ServiceManagerService can not be configured with nil logger') if logger.nil?
     @@url = url
-    @@logger = logger
-    @@logger.debug(method) {'entered'}
+    GtkApi.logger.debug(method) {"entered with url=#{url}"}
   end
 
   def self.url
-    @@logger.debug(LOG_MESSAGE + "#url") {'@@url='+@@url}
+    GtkApi.logger.debug(LOG_MESSAGE + "#url") {'@@url='+@@url}
     @@url
   end
 
   def self.find_service_by_uuid(uuid:, params: {})
-    find(url: @@url + '/services/' + uuid, params: params, log_message: LOG_MESSAGE + "##{__method__}(#{uuid})", logger: @@logger)
+    find(url: @@url + '/services/' + uuid, params: params, log_message: LOG_MESSAGE + "##{__method__}(#{uuid})")
   end
   
   def self.find_services(params)
     log_message = LOG_MESSAGE + "##{__method__}(#{params})"
-    @@logger.debug(log_message) {'entered'}
-    services=find(url: @@url + '/services', params: params, log_message: LOG_MESSAGE + "##{__method__}(#{params})", logger: @@logger)
+    GtkApi.logger.debug(log_message) {'entered'}
+    services=find(url: @@url + '/services', params: params, log_message: LOG_MESSAGE + "##{__method__}(#{params})")
     vectorize_hash services
  end
 
   def self.find_requests(params)
     log_message = LOG_MESSAGE + "##{__method__}(#{params})"
-    @@logger.debug(log_message) {'entered'}
-    requests=find(url: @@url + '/requests', params: params, log_message: LOG_MESSAGE + "##{__method__}(#{params})", logger: @@logger)
+    GtkApi.logger.debug(log_message) {'entered'}
+    requests=find(url: @@url + '/requests', params: params, log_message: LOG_MESSAGE + "##{__method__}(#{params})")
     vectorize_hash requests
   end
   
   def self.find_requests_by_uuid(uuid)
     log_message = LOG_MESSAGE + "##{__method__}(#{params})"
-    @@logger.debug(log_message) {'entered'}
-    find(url: @@url + '/requests/' + uuid, log_message: LOG_MESSAGE + "##{__method__}(#{uuid})", logger: @@logger)
+    GtkApi.logger.debug(log_message) {'entered'}
+    find(url: @@url + '/requests/' + uuid, log_message: LOG_MESSAGE + "##{__method__}(#{uuid})")
   end
   
   def self.create_service_intantiation_request(params)
     method = LOG_MESSAGE + "##{__method__}(#{params})"
-    @@logger.debug(method) {'entered'}
+    GtkApi.logger.debug(method) {'entered'}
 
     begin
-      @@logger.debug(method) {"@url = "+@@url}
+      GtkApi.logger.debug(method) {"@url = "+@@url}
       response = self.postCurb(url: @@url+'/requests', body: params.to_json) ## TODO: check if this tests ok!! 
-      @@logger.debug(method) {"response=#{response}"}
+      GtkApi.logger.debug(method) {"response=#{response}"}
       response
     rescue => e
-      @@logger.error(method) {"Error during processing: #{$!}"}
-      @@logger.error(method) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"}
+      GtkApi.logger.error(method) {"Error during processing: #{$!}"}
+      GtkApi.logger.error(method) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"}
       nil 
     end      
   end
   
   def self.create_service_update_request(nsr_uuid:, nsd:)
     message = LOG_MESSAGE+'.create_service_update_request'
-    @@logger.debug(message) {'entered'}
-    @@logger.debug(message) {"service instance=#{nsr_uuid}, nsd=#{nsd}"}
+    GtkApi.logger.debug(message) {'entered'}
+    GtkApi.logger.debug(message) {"service instance=#{nsr_uuid}, nsd=#{nsd}"}
     begin
-      @@logger.debug(message) {"@url = "+@@url}
+      GtkApi.logger.debug(message) {"@url = "+@@url}
       #response = RestClient.put(@url+'/services/'+nsr_uuid, nsd.to_json, content_type: :json, accept: :json) 
       response = self.postCurb(url: @@url+'/services/'+nsr_uuid, body: nsd.to_json) 
-      @@logger.debug(message) {"response="+response}
+      GtkApi.logger.debug(message) {"response="+response}
       response
     rescue => e
-      @@logger.error(method) {"Error during processing: #{$!}"}
-      @@logger.error(method) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"}
+      GtkApi.logger.error(method) {"Error during processing: #{$!}"}
+      GtkApi.logger.error(method) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"}
       nil 
     end      
   end

--- a/son-gtkapi/models/vim_manager_service.rb
+++ b/son-gtkapi/models/vim_manager_service.rb
@@ -33,57 +33,50 @@ class VimManagerService < ManagerService
   CLASS_NAME = self.name
   LOG_MESSAGE = 'GtkApi::' + CLASS_NAME
 
-  def self.config(url:, logger:)
-    method = LOG_MESSAGE + "##{__method__}(url=#{url}, logger=#{logger})"
+  def self.config(url:)
+    method = LOG_MESSAGE + "##{__method__}(url=#{url})"
     raise ArgumentError, CLASS_NAME+' can not be configured with nil url' if url.nil?
     raise ArgumentError, CLASS_NAME+' can not be configured with empty url' if url.empty?
-    raise ArgumentError, CLASS_NAME+' can not be configured with nil logger' if logger.nil?
     @@url = url
-    @@logger = logger
-    @@logger.debug(method) {'entered'}
-  end
-
-  def self.url
-    @@logger.debug(LOG_MESSAGE + "#url") {'@@url='+@@url}
-    @@url
+    GtkApi.logger.debug(method) {'entered'}
   end
 
   def self.find_vims(params)
     method = LOG_MESSAGE + "##{__method__}(#{params})"
-    @@logger.debug(method) {'entered'}
+    GtkApi.logger.debug(method) {'entered'}
     begin
-      response = getCurb(url:self.url+'/vim', headers:JSON_HEADERS, logger:@@logger)
-      @@logger.debug(method) {'response='+response.to_s}
+      response = getCurb(url:@@url+'/vim', headers:JSON_HEADERS, logger:@@logger)
+      GtkApi.logger.debug(method) {'response='+response.to_s}
       response
     rescue => e
-      @@logger.error(method) {"Error during processing: #{$!}"}
-      @@logger.error(method) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"}
+      GtkApi.logger.error(method) {"Error during processing: #{$!}"}
+      GtkApi.logger.error(method) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"}
       nil
     end
   end
 
   def self.create_vim(params)
     method = LOG_MESSAGE + "##{__method__}(#{params})"
-    @@logger.debug(method) {"entered"}
+    GtkApi.logger.debug(method) {"entered"}
 
     begin
-      @@logger.debug(method) {"@url = " + self.url}
-      response = postCurb(url:self.url+'/vim', body: params.to_json)
-      @@logger.debug(method) {"response="+response}
+      GtkApi.logger.debug(method) {"@url = " + @@url}
+      response = postCurb(url:@@url+'/vim', body: params.to_json)
+      GtkApi.logger.debug(method) {"response="+response}
       response
     rescue => e
-      @@logger.error(method) {"Error during processing: #{$!}"}
-      @@logger.error(method) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"}
+      GtkApi.logger.error(method) {"Error during processing: #{$!}"}
+      GtkApi.logger.error(method) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"}
       nil
     end
   end
 
   def self.find_vim_request_by_uuid(uuid)
     method = LOG_MESSAGE + "##{__method__}(#{uuid})"
-    @@logger.debug(method) {'entered'}
+    GtkApi.logger.debug(method) {'entered'}
     begin
-      response = getCurb(url:self.url+'/vim_requests/'+uuid, headers: JSON_HEADERS)
-      @@logger.debug(method) {"Got response: #{response}"}
+      response = getCurb(url:@@url+'/vim_requests/'+uuid, headers: JSON_HEADERS)
+      GtkApi.logger.debug(method) {"Got response: #{response}"}
       query_response = response[:items][:query_response]
       if query_response
         JSON.parse  query_response
@@ -91,8 +84,8 @@ class VimManagerService < ManagerService
         {}
       end
     rescue => e
-      @@logger.error(method) {"Error during processing: #{$!}"}
-      @@logger.error(method) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"}
+      GtkApi.logger.error(method) {"Error during processing: #{$!}"}
+      GtkApi.logger.error(method) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"}
       nil
     end
   end

--- a/son-gtkapi/routes/function.rb
+++ b/son-gtkapi/routes/function.rb
@@ -78,9 +78,10 @@ class GtkApi < Sinatra::Base
     get '/logs/?' do
       log_message = 'GtkApi::GET /admin/functions/logs'
       logger.debug(log_message) {'entered'}
-      headers 'Content-Type' => 'text/plain; charset=utf8', 'Location' => '/'
-      log = FunctionManagerService.get_log(url:FunctionManagerService.url+'/admin/logs', log_message:log_message, logger: logger)
+      url = FunctionManagerService.class_variable_get(:@@url)+'/admin/logs'
+      log = FunctionManagerService.get_log(url: url, log_message:log_message, logger: logger)
       logger.debug(log_message) {'leaving with log='+log}
+      headers 'Content-Type' => 'text/plain; charset=utf8', 'Location' => '/'
       halt 200, log
     end
   end

--- a/son-gtkapi/routes/licence.rb
+++ b/son-gtkapi/routes/licence.rb
@@ -195,9 +195,10 @@ class GtkApi < Sinatra::Base
     get '/logs/?' do
       log_message = 'GtkApi::GET /api/v2/admin/licences/logs'
       logger.debug(log_message) {'entered'}
-      headers 'Content-Type' => 'text/plain; charset=utf8', 'Location' => '/'
-      log = LicenceManagerService.get_log(url:LicenceManagerService.url+'/admin/logs', log_message:log_message, logger: logger)
+      url = LicenceManagerService.class_variable_get(:@@url)+'/admin/logs'
+      log = LicenceManagerService.get_log(url: url, log_message:log_message, logger: logger)
       logger.debug(log_message) {'leaving with log='+log}
+      headers 'Content-Type' => 'text/plain; charset=utf8', 'Location' => '/'
       halt 200, log
     end
   end

--- a/son-gtkapi/routes/package.rb
+++ b/son-gtkapi/routes/package.rb
@@ -134,9 +134,10 @@ class GtkApi < Sinatra::Base
     get '/logs/?' do
       log_message = 'GtkApi::GET /api/v2/admin/packages/logs'
       logger.debug(log_message) {'entered'}
-      headers 'Content-Type' => 'text/plain; charset=utf8', 'Location' => '/'
-      log = PackageManagerService.get_log(url:PackageManagerService.url+'/admin/logs', log_message:log_message, logger: logger)
+      url = PackageManagerService.class_variable_get(:@@url)+'/admin/logs'
+      log = PackageManagerService.get_log(url: url, log_message:log_message, logger: logger)
       logger.debug(log_message) {'leaving with log='+log}
+      headers 'Content-Type' => 'text/plain; charset=utf8', 'Location' => '/'
       halt 200, log #.to_s
     end
   end

--- a/son-gtkapi/routes/record.rb
+++ b/son-gtkapi/routes/record.rb
@@ -130,9 +130,10 @@ class GtkApi < Sinatra::Base
     get '/logs/?' do
       log_message = "GtkApi::GET /api/v2/admin/records/logs"
       logger.debug(log_message) {"entered"}
-      headers 'Content-Type' => 'text/plain; charset=utf8', 'Location' => '/'
-      log = RecordManagerService.get_log(url:RecordManagerService.url+'/admin/logs', log_message:log_message, logger: logger)
+      url = RecordManagerService.class_variable_get(:@@url)+'/admin/logs'
+      log = RecordManagerService.get_log(url: url, log_message:log_message, logger: logger)
       logger.debug(log_message) {'leaving with log='+log}
+      headers 'Content-Type' => 'text/plain; charset=utf8', 'Location' => '/'
       halt 200, log #.to_s
     end
   end

--- a/son-gtkapi/routes/request.rb
+++ b/son-gtkapi/routes/request.rb
@@ -103,9 +103,10 @@ class GtkApi < Sinatra::Base
     get '/logs/?' do
       log_message = "GtkApi::GET /api/v2/admin/requests/logs"
       logger.debug(log_message) {"entered"}
-      headers 'Content-Type' => 'text/plain; charset=utf8', 'Location' => '/api/v2/admin/requests/logs'
-      log = ServiceManagerService.get_log(url:ServiceManagerService.url+'/admin/logs', log_message:log_message, logger: logger)
+      url = ServiceManagerService.class_variable_get(:@@url)+'/admin/logs'
+      log = ServiceManagerService.get_log(url: url, log_message:log_message, logger: logger)
       logger.debug(log_message) {'leaving with log='+log}
+      headers 'Content-Type' => 'text/plain; charset=utf8', 'Location' => '/api/v2/admin/requests/logs'
       halt 200, log
     end
   end

--- a/son-gtkapi/routes/service.rb
+++ b/son-gtkapi/routes/service.rb
@@ -101,7 +101,8 @@ class GtkApi < Sinatra::Base
       log_message = 'GtkApi::GET /admin/services/logs'
       logger.debug(log_message) {'entered'}
       headers 'Content-Type' => 'text/plain; charset=utf8', 'Location' => '/'
-      log = ServiceManagerService.get_log(url:ServiceManagerService.url+'/admin/logs', log_message:log_message, logger: logger)
+      url = ServiceManagerService.class_variable_get(:@@url)+'/admin/logs'
+      log = ServiceManagerService.get_log(url: url, log_message:log_message, logger: logger)
       logger.debug(log_message) {'leaving with log='+log}
       halt 200, log
     end

--- a/son-gtkapi/routes/vim.rb
+++ b/son-gtkapi/routes/vim.rb
@@ -98,9 +98,10 @@ class GtkApi < Sinatra::Base
     get '/logs/?' do
       log_message = 'GtkApi::GET /api/v2/admin/vims/logs'
       logger.debug(log_message) {'entered'}
-      headers 'Content-Type' => 'text/plain; charset=utf8', 'Location' => '/'
-      log = VimManagerService.get_log(url:VimManagerService.url+'/admin/logs', log_message:log_message, logger: logger)
+      url = VimManagerService.class_variable_get(:@@url)+'/admin/logs'
+      log = VimManagerService.get_log(url: url, log_message:log_message, logger: logger)
       logger.debug(log_message) {'leaving with log='+log}
+      headers 'Content-Type' => 'text/plain; charset=utf8', 'Location' => '/'
       halt 200, log
     end
   end

--- a/son-gtkapi/spec/spec_helper.rb
+++ b/son-gtkapi/spec/spec_helper.rb
@@ -46,6 +46,7 @@ RSpec.configure do |config|
   #config.color_enabled = true
   config.tty = true
   config.formatter = :documentation
+  config.profile_examples = 3
 end
 
 WebMock.disable_net_connect!() #allow_localhost: true)


### PR DESCRIPTION
In Sinatra, logger is set globally, but we were using it as an extra parameter/class variable. This now better, used through `GtkApi.logger`.