### PR TITLE
Remove bugs in package manager and VIM services

### DIFF
--- a/son-gtkapi/models/package_manager_service.rb
+++ b/son-gtkapi/models/package_manager_service.rb
@@ -1,28 +1,28 @@
 ##
 ## Copyright (c) 2015 SONATA-NFV [, ANY ADDITIONAL AFFILIATION]
 ## ALL RIGHTS RESERVED.
-## 
+##
 ## Licensed under the Apache License, Version 2.0 (the "License");
 ## you may not use this file except in compliance with the License.
 ## You may obtain a copy of the License at
-## 
+##
 ##     http://www.apache.org/licenses/LICENSE-2.0
-## 
+##
 ## Unless required by applicable law or agreed to in writing, software
 ## distributed under the License is distributed on an "AS IS" BASIS,
 ## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
-## 
+##
 ## Neither the name of the SONATA-NFV [, ANY ADDITIONAL AFFILIATION]
-## nor the names of its contributors may be used to endorse or promote 
-## products derived from this software without specific prior written 
+## nor the names of its contributors may be used to endorse or promote
+## products derived from this software without specific prior written
 ## permission.
-## 
+##
 ## This work has been performed in the framework of the SONATA project,
-## funded by the European Commission under Grant number 671517 through 
-## the Horizon 2020 and 5G-PPP programmes. The authors would like to 
-## acknowledge the contributions of their colleagues of the SONATA 
+## funded by the European Commission under Grant number 671517 through
+## the Horizon 2020 and 5G-PPP programmes. The authors would like to
+## acknowledge the contributions of their colleagues of the SONATA
 ## partner consortium (www.sonata-nfv.eu).
 # encoding: utf-8
 require 'tempfile'
@@ -30,10 +30,12 @@ require './models/manager_service.rb'
 
 class PackageManagerService < ManagerService
 
-  attr_reader :url, :logger
-  
   LOG_MESSAGE = 'GtkApi::' + self.name
-  
+
+  def self.url
+    @@url
+  end
+
   def self.config(url:)
     method = LOG_MESSAGE + "#config(url=#{url})"
     raise ArgumentError.new('PackageManagerService can not be configured with nil url') if url.nil?
@@ -46,7 +48,6 @@ class PackageManagerService < ManagerService
     method = LOG_MESSAGE + ".create"
     GtkApi.logger.debug(method) {'entered'}
 
-    tmpfile = params[:package][:tempfile]
     uri = @@url+'/packages'
     GtkApi.logger.debug(method) {"POSTing to "+uri+ "#{params}"}
     begin
@@ -56,9 +57,9 @@ class PackageManagerService < ManagerService
         GtkApi.logger.debug(method) {"response=#{response.inspect}"}
         case response.code
         when 201
-          { status: 201, count: 1, data: JSON.parse(response.body), message: 'Created'}
+          { status: 201, count: 1, data: JSON.parse(response.body, :symbolize_names => true), message: 'Created'}
         when 409
-          { status: 409, count: 0, data: JSON.parse(response.body), message: 'Conflict'}
+          { status: 409, count: 0, data: JSON.parse(response.body, :symbolize_names => true), message: 'Conflict'}
         when 400
           { status: 400, count: 0, data: {}, message: "Bad Request: #{params}"}
         else
@@ -69,7 +70,7 @@ class PackageManagerService < ManagerService
       GtkApi.logger.error(method) {"Error during processing: #{$!}"}
       GtkApi.logger.error(method) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"}
       { status: 500, count: 0, data: {}, message: e.backtrace.join("\n\t")}
-    end    
+    end
   end
 
   def self.find_by_uuid(uuid)
@@ -85,7 +86,7 @@ class PackageManagerService < ManagerService
       e.to_json
     end
   end
-  
+
   def self.find(params)
     method = LOG_MESSAGE + ".find(#{params})"
     GtkApi.logger.debug(method) {'entered'}

--- a/son-gtkapi/models/vim_manager_service.rb
+++ b/son-gtkapi/models/vim_manager_service.rb
@@ -62,7 +62,7 @@ class VimManagerService < ManagerService
     begin
       GtkApi.logger.debug(method) {"@url = " + @@url}
       response = postCurb(url:@@url+'/vim', body: params.to_json)
-      GtkApi.logger.debug(method) {"response="+response}
+      GtkApi.logger.debug(method) {"response="+response.to_s}
       response
     rescue => e
       GtkApi.logger.error(method) {"Error during processing: #{$!}"}
@@ -79,7 +79,7 @@ class VimManagerService < ManagerService
       GtkApi.logger.debug(method) {"Got response: #{response}"}
       query_response = response[:items][:query_response]
       if query_response
-        JSON.parse  query_response
+        query_response
       else
         {}
       end

--- a/son-gtkpkg/models/package.rb
+++ b/son-gtkpkg/models/package.rb
@@ -345,7 +345,7 @@ class Package
       saved_descriptor=store()
       if saved_descriptor
         @logger.debug "Package.store_package_service_and_functions: stored package #{saved_descriptor}"
-        if @service
+        if @service.size > 0
           @logger.debug "Package.store_package_service_and_functions: service is #{@service}"
           stored_service = @service.store()
           if stored_service
@@ -356,7 +356,7 @@ class Package
             @logger.debug "Package.store_package_service_and_functions: service and package rollback should happen here"
           end
         end
-        if @functions.size
+        if @functions.size > 0
           @functions.each do |vf|
             @logger.debug "Package.store_package_service_and_functions: vf = #{vf}"
             function = vf.store()


### PR DESCRIPTION
-Package manager does not use logger and url instance members anymore
so they are removed
-Acces method added to package manager service for static 'url' field
-Unused variable deleted from package manager service
-Symbolize names options is given to JSON parser in package manager, so
the callers of the create function can use 'resp[:data][:uuid]' notation
-In VIM manager service explicit conversion is given to the log message and
unnecessary parsing is deleted (response is already parsed in getCurb
-gtkpgk's package services is updated to handle the case when there
is no service or function is defined in the uploaded package (ruby
handle everything as true on default except nil and false)