### PR TITLE
 Fix missing method to access class variable

### DIFF
--- a/son-gtkapi/models/licence_manager_service.rb
+++ b/son-gtkapi/models/licence_manager_service.rb
@@ -62,6 +62,15 @@ class LicenceManagerService < ManagerService
   end
   
   def self.valid?(params)
+    # service_uuid, string, mandatory
+    # user_uuid, string, mandatory
+    # license_uuid, string, mandatory
+    # license_type, string, mandatory
+    # description, string
+    # validation_url, string
+    # status, string, mandatory
+
+    
     method = LOG_MESSAGE + "##{__method__}(#{params})"
     GtkApi.logger.debug(method) {'entered'}
     raise ArgumentError, 'User must be valid' unless User.valid? params[:user_uuid]
@@ -75,6 +84,7 @@ class LicenceManagerService < ManagerService
     GtkApi.logger.debug(method) {'entered'}
     headers = {'Content-Type'=>'application/x-www-form-urlencoded'}
 
+    
     begin
       self.valid?(params)
       licence = postCurb(url: @@url+LICENCES_URL, body: params, headers: headers)

--- a/son-gtkapi/models/service_manager_service.rb
+++ b/son-gtkapi/models/service_manager_service.rb
@@ -40,11 +40,6 @@ class ServiceManagerService < ManagerService
     GtkApi.logger.debug(method) {"entered with url=#{url}"}
   end
 
-  def self.url
-    GtkApi.logger.debug(LOG_MESSAGE + "#url") {'@@url='+@@url}
-    @@url
-  end
-
   def self.find_service_by_uuid(uuid:, params: {})
     find(url: @@url + '/services/' + uuid, params: params, log_message: LOG_MESSAGE + "##{__method__}(#{uuid})")
   end

--- a/son-gtkapi/routes/licence.rb
+++ b/son-gtkapi/routes/licence.rb
@@ -144,7 +144,7 @@ class GtkApi < Sinatra::Base
       logger.debug(log_message) {"licence_type=#{licence_type.inspect}"}
       if licence_type
         logger.info(log_message) {"leaving with licence_type: #{licence_type}"}
-        headers 'Location'=> LicenceManagerService.url+"/licence-types/#{licence_type[:uuid]}", 'Content-Type'=> 'application/json'
+        headers 'Location'=> LicenceManagerService.class_variable_get(:@@url)+"/licence-types/#{licence_type[:uuid]}", 'Content-Type'=> 'application/json'
         halt 201, licence_type.to_json
       else
         json_error 400, 'Licence type not created'
@@ -177,7 +177,7 @@ class GtkApi < Sinatra::Base
       case licence[:status]
       when 201
         logger.info(log_message) {"leaving with licence: #{licence[:items]}"}
-        headers 'Location'=> LicenceManagerService.url+"/licences/#{licence[:uuid]}", 'Content-Type'=> 'application/json'
+        headers 'Location'=> LicenceManagerService.class_variable_get(:@@url)+"/licences/#{licence[:uuid]}", 'Content-Type'=> 'application/json'
         halt 201, licence.to_json
       when 422
         logger.info(log_message) {"Unprocessable entity"}

--- a/son-gtkapi/routes/package.rb
+++ b/son-gtkapi/routes/package.rb
@@ -43,7 +43,7 @@ class GtkApi < Sinatra::Base
           case resp[:status]
           when 201
             logger.info(log_message) {"leaving with package: #{resp[:data][:uuid]}"}
-            headers 'Location'=> PackageManagerService.url+"/packages/#{resp[:data][:uuid]}", 'Content-Type'=> 'application/json'
+            headers 'Location'=> PackageManagerService.class_variable_get(:@@url)+"/packages/#{resp[:data][:uuid]}", 'Content-Type'=> 'application/json'
             halt 201, resp[:data].to_json
           when 409
             logger.error(log_message) {"leaving with duplicated package: #{resp[:data]}"}

--- a/son-gtkapi/spec/models/service_manager_service_spec.rb
+++ b/son-gtkapi/spec/models/service_manager_service_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ServiceManagerService, type: :model do
   let(:service_to_be_created_2) {{name:'name', version:'0.2', vendor:'vendor'}}
   let(:created_service_2) {service_to_be_created_2.merge({uuid: service_uuid})}
   let(:all_services) { [ created_service_1, created_service_2 ]}
-  let(:services_url) { ServiceManagerService.url+'/services' }
+  let(:services_url) { ServiceManagerService.class_variable_get(:@@url)+'/services' }
   describe '#find_services' do
     it 'with default parameters should return two services' do
       resp = OpenStruct.new(header_str: "HTTP/1.1 200 OK\nRecord-Count: 2", body: all_services.to_json)      

--- a/son-gtkapi/spec/requests/services_spec.rb
+++ b/son-gtkapi/spec/requests/services_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe GtkApi, type: :controller do
     uuid: service2_uuid
   }}
   let(:services) { [ service1, service2 ]}
-  let(:services_url) { ServiceManagerService.url+'/services' }
+  let(:services_url) { ServiceManagerService.class_variable_get(:@@url)+'/services' }
   let(:full_services_url) {services_url+'?offset='+GtkApi::DEFAULT_OFFSET+'&limit='+GtkApi::DEFAULT_LIMIT}
   
   describe 'GET /api/v2/services' do


### PR DESCRIPTION
We were using a class method (`def self.url() @@url end`), we're replacing by `<class>..class_variable_get(:@@url)`: less readable, but more explicit?