### PR TITLE
420 log into both a file and stdout

### DIFF
--- a/son-gtkapi/Dockerfile
+++ b/son-gtkapi/Dockerfile
@@ -6,6 +6,7 @@ RUN mkdir -p /app
 WORKDIR /app
 COPY Gemfile /app
 RUN bundle install
+RUN mkdir -p /var/log/sonata
 COPY . /app
 EXPOSE 5000
 WORKDIR /app

--- a/son-gtkapi/config/configs.yml.erb
+++ b/son-gtkapi/config/configs.yml.erb
@@ -33,7 +33,8 @@ development: &common_settings
   recmgmt: <%= ENV['RECORD_MANAGEMENT_URL'] %>
   licmgmt: <%= ENV['LICENCE_MANAGEMENT_URL'] %>
   kpimgmt: <%= ENV['KPI_MANAGEMENT_URL'] %>
-  logger_level: <%= ENV['LOGGER_LEVEL'] %>
+  level: <%= ENV['LEVEL'] %>
+  log_file_name: <%= ENV['LOG_FILE_NAME'] %>
 
 test:
   <<: *common_settings

--- a/son-gtkapi/config/services.yml
+++ b/son-gtkapi/config/services.yml
@@ -26,16 +26,15 @@
 # partner consortium (www.sonata-nfv.eu).
 # encoding: utf-8
 development: &common_settings
-  pkgmgmt: <%= ENV['PACKAGE_MANAGEMENT_URL'] %>
-  srvmgmt: <%= ENV['SERVICE_MANAGEMENT_URL'] %>
-  fnctmgmt: <%= ENV['FUNCTION_MANAGEMENT_URL'] %>
-  vimmgmt: <%= ENV['VIM_MANAGEMENT_URL'] %>
-  recmgmt: <%= ENV['RECORD_MANAGEMENT_URL'] %>
-  licmgmt: <%= ENV['LICENCE_MANAGEMENT_URL'] %>
-  kpimgmt: <%= ENV['KPI_MANAGEMENT_URL'] %>
-  level: <%= ENV['LEVEL'] %>
-  log_file_name: <%= ENV['LOG_FILE_NAME'] %>
-
+  services:
+    packages
+    services
+    functions
+    records
+    vims
+    licences
+    kpis
+    
 test:
   <<: *common_settings
 

--- a/son-gtkapi/gtk_api.rb
+++ b/son-gtkapi/gtk_api.rb
@@ -89,7 +89,8 @@ class GtkApi < Sinatra::Base
   logfile.sync = true
   set :logger, Logger.new(logfile)
 
-  configure :integration, :qualification, :demonstration do
+  # logs in :development, :test and :integration go also to $stdout and $stderr
+  configure :qualification, :demonstration do
     $stdout.reopen(logfile)
     $stderr.reopen(logfile)
     $stdout.sync = true

--- a/son-gtkapi/gtk_api.rb
+++ b/son-gtkapi/gtk_api.rb
@@ -73,10 +73,6 @@ class GtkApi < Sinatra::Base
   MODULE = 'GtkApi'
 
 	enable :logging
-  # don't enable logging when running tests 
-  configure :integration, :qualification, :demonstration do
-    enable :logging
-  end
   
   #FileUtils.mkdir(File.join(settings.root, 'log')) unless File.exists? File.join(settings.root, 'log')
   # File.symbolic('/dev/stdout', '/var/log/sonata/son-gtkapi.log')
@@ -87,10 +83,13 @@ class GtkApi < Sinatra::Base
   logfile = File.open(File.join(folder, name), 'a+')
   logfile.sync = true
   set :logger, Logger.new(logfile)
-  $stdout.reopen(logfile)
-  $stderr.reopen(logfile)
-  $stdout.sync = true
-  $stderr.sync = true
+
+  configure :integration, :qualification, :demonstration do
+    $stdout.reopen(logfile)
+    $stderr.reopen(logfile)
+    $stdout.sync = true
+    $stderr.sync = true
+  end
 
   raise 'Can not proceed without a logger file' if settings.logger.nil?
   set :logger_level, (settings.level ||= 'debug').to_sym # can be debug, fatal, error, warn, or info


### PR DESCRIPTION
Except for `:development` and `:test`, all other environments get their logging redirected to `$stdout` and `$stderr`. Log file name can now be specified in an environment variable (`LOG_FILE_NAME`), which defaults to `/var/log/sonata/son-gtkapi.log`.