### PR TITLE
First KPIs collected: single package metadata queries and downloads

### DIFF
--- a/son-gtkapi/models/kpi_manager_service.rb
+++ b/son-gtkapi/models/kpi_manager_service.rb
@@ -29,7 +29,6 @@ require './models/manager_service.rb'
 
 class KpiManagerService < ManagerService
   
-  JSON_HEADERS = { 'Accept'=> 'application/json', 'Content-Type'=>'application/json'}
   LOG_MESSAGE = 'GtkApi::' + self.name
   
   def self.config(url:)
@@ -49,9 +48,9 @@ class KpiManagerService < ManagerService
       response = putCurb(url: @@url+'/kpis', body: params)      
       case response
       when 201
-        { status: response, data: {}, message: 'Metric Updated'}        
+        { status: response, data: {}, message: 'Metric updated'}        
       else
-        { status: response, data: {}, message: 'Metric does not updated'}
+        { status: response, data: {}, message: 'Metric was not updated'}
       end      
     rescue => e
       GtkApi.logger.error(method) {"Error during processing: #{$!}"}

--- a/son-gtkapi/models/manager_service.rb
+++ b/son-gtkapi/models/manager_service.rb
@@ -30,6 +30,7 @@ class ManagerService
   JSON_HEADERS = { 'Accept'=> 'application/json', 'Content-Type'=>'application/json'}
   CLASS_NAME = self.name
   LOG_MESSAGE = 'GtkApi::' + CLASS_NAME
+  BASE_KPI_PARAMS = { "job": "sonata", "instance": "gtkapi"}
   
   def initialize(url, logger)
     method = 'GtkApi::' + CLASS_NAME + ".new(url=#{url}, logger=#{logger})"
@@ -194,5 +195,13 @@ class ManagerService
       items: hash[:items].is_a?(Hash) ? [hash[:items]] : hash[:items], 
       message: hash[:message]
     }
+  end
+  
+  def self.counter_kpi(params)
+    # params should have
+    #  "name": "example_counter"
+    #  "docstring": "metric counter test"
+    #  "base_labels": {"result": "ok", "time-taken": (Time.now.utc-began_at).to_s} --> examples
+    KpiManagerService.update_metric(BASE_KPI_PARAMS.merge(params).merge({metric_type: "counter"}))
   end
 end


### PR DESCRIPTION
First attempt to collect GK API's KPIs:

- `GET .../packages/<uuid>`
- `GET .../packages/<uuid>/download`
