### PR TITLE
Implement (partially) user creation.

### DIFF
--- a/son-gtkapi/config/api.yml
+++ b/son-gtkapi/config/api.yml
@@ -7,7 +7,7 @@
   host: "sp.sonata-nfv.eu"
   schemes: 
     - "https"
-  basePath: "/api"
+  basePath: "/api/v2"
   produces: 
     - "application/json"
   paths: 
@@ -495,6 +495,52 @@
           500: 
             $ref: "#/responses/Standard500ErrorResponse"
     /micro-services/public-key: 
+      get: 
+        summary: "Gets User Management module public key."
+        description: "Returns User Management module public key, so that 'client' modules can decryt token"
+        operationId: "getPublicKey"
+        produces: 
+          - "application/json"
+        tags: 
+          - "Micro-Services"
+          - "Public Key"
+        responses: 
+          200: 
+            description: "Public Key is returned"
+            schema: 
+              $ref: "#/definitions/ServiceInstance"
+          404: 
+            $ref: "#/responses/RequiredRecordDoesNotExistResponse"
+          500: 
+            $ref: "#/responses/Standard500ErrorResponse"
+    /users: 
+      get: 
+        summary: "Get the list of all the registered users"
+        description: ""
+        operationId: "find"
+        produces: 
+          - "application/json"
+        parameters: 
+          - 
+            in: "header"
+            name: "Authorization"
+            description: "The type of authorization required"
+            required: false
+            type: "string"
+          - 
+            $ref: "#/parameters/offset"
+          - 
+            $ref: "#/parameters/limit"
+        tags: 
+          - "Users"
+        responses: 
+          200: 
+            description: "Instances list returned"
+            schema: 
+              $ref: "#/definitions/ServiceInstances"
+          500: 
+            $ref: "#/responses/Standard500ErrorResponse"
+    /users/public-key: 
       get: 
         summary: "Gets User Management module public key."
         description: "Returns User Management module public key, so that 'client' modules can decryt token"

--- a/son-gtkapi/models/manager_service.rb
+++ b/son-gtkapi/models/manager_service.rb
@@ -109,7 +109,7 @@ class ManagerService
         {status: nil, count: nil, items: nil, message: "Error processing #{$!}: \n\t#{e.backtrace.join("\n\t")}"}
       end
     when 400..499
-      {status: status, count: nil, items: nil, message: "Status #{status}: cold not process"}
+      {status: status, count: nil, items: nil, message: "Status #{status}: could not process"}
     else
       {status: status, count: nil, items: nil, message: "Status #{status} unknown"}
     end
@@ -182,8 +182,7 @@ class ManagerService
       when 200
         res.body
       else
-        GtkApi.logger.error(log_message) {"Error during processing: #{$!}"}
-        GtkApi.logger.error(log_message) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"}
+        GtkApi.logger.error(log_message) {"Error retrieving logs"}
         nil
       end
   end

--- a/son-gtkapi/routes/micro_services_controller.rb
+++ b/son-gtkapi/routes/micro_services_controller.rb
@@ -110,7 +110,7 @@ class GtkApi < Sinatra::Base
 
     # GET .../api/v2/micro-services/users/public-key: To get the UM's public-key:
     get '/public-key/?' do
-      log_message = 'GtkApi:: GET /api/v2/micro-services/users/public-key'
+      log_message = 'GtkApi:: GET /api/v2/micro-services/public-key'
       logger.debug(log_message) {"entered with #{params}"}
     
       begin

--- a/son-gtkapi/spec/models/user_spec.rb
+++ b/son-gtkapi/spec/models/user_spec.rb
@@ -76,16 +76,21 @@ RSpec.describe User, type: :model do
   describe '.authenticated?'
   describe '.logout!'
   describe '#create' do
+    # expect(@object).to be_a Shirt
     let(:users_url) {User.class_variable_get(:@@url)+'/api/v1/register/user'}
     let(:user_basic_info) {{
-      enabled: true, totp: false, emailVerified: false,
       firstName: "Un", lastName: "Known",
-      requiredActions: [], federatedIdentities: [],
-      attributes: {developer: ["true"], customer: ["false"], admin: ["false"]}, 
-      realmRoles: [], clientRoles: {}, groups: ["developers"]}
-    }
-    let(:user_info) {user_basic_info.merge({username: "Unknown", email: "user.sample@email.com.br", credentials: [ {type: "password", value: "1234"} ]})}
-    let(:created_user) { user_info.merge({uuid:SecureRandom.uuid})}
+      user_type: "developer"
+      }}
+    let(:user_info) {user_basic_info.merge({username: "Unknown", email: "un@known.com", password: "1234"})}
+    let(:created_user) {{
+      uuid:SecureRandom.uuid,
+      firstName: "Un", lastName: "Known",
+      username: "Unknown", email: "un@known.com",
+      credentials: [{type: 'password', value: '1234'}],
+      attributes: {developer:['true']},
+      token: '123'
+    }}
       
     context 'successfuly' do
       before(:each) do
@@ -93,7 +98,7 @@ RSpec.describe User, type: :model do
         allow(Curl).to receive(:post).with(users_url, user_info).and_return(resp) 
       end
       it 'should return 201' do
-        expect(User.create(user_info)).to eq({status: 201, count: 1, items: created_user, message: "OK"})
+        expect(User.create(user_info)).to be_a User #eq({status: 201, count: 1, items: created_user, message: "OK"})
       end
       it 'should call User Management Service' do
         User.create(user_info)

--- a/son-gtkapi/spec/routes/users_controller_spec.rb
+++ b/son-gtkapi/spec/routes/users_controller_spec.rb
@@ -33,17 +33,23 @@ require 'base64'
 RSpec.describe GtkApi, type: :controller do
   include Rack::Test::Methods
   def app() GtkApi end
+    # expect(@object).to be_a Shirt
 
   describe 'POST /api/v2/users' do
     let(:user_basic_info) {{
-      enabled: true, totp: false, emailVerified: false,
       firstName: "Un", lastName: "Known",
-      requiredActions: [], federatedIdentities: [],
-      attributes: {developer: ["true"], customer: ["false"], admin: ["false"]}, 
-      realmRoles: [], clientRoles: {}, groups: ["developers"]}
-    }
-    let(:user_info) {user_basic_info.merge({username: "Unknown", email: "user.sample@email.com.br", credentials: [ {type: "password", value: "1234"} ]})}
-    let(:user_with_no_name) {user_basic_info.merge({username: "", email: "user.sample@email.com.br", credentials: [ {type: "password", value: "1234"} ]})}
+      user_type: "developer"
+      }}
+    let(:user_info) {user_basic_info.merge({username: "Unknown", email: "un@known.com", password: "1234"})}
+    let(:created_user) {{
+      uuid:SecureRandom.uuid,
+      firstName: "Un", lastName: "Known",
+      username: "Unknown", email: "un@known.com",
+      credentials: [{type: 'password', value: '1234'}],
+      attributes: {developer:['true']},
+      token: '123'
+    }}
+    let(:user_with_no_name) {user_basic_info.merge({username: "", email: "un@known.com", password: "1234"})}
     it 'without user name given returns Unprocessable Entity (400)' do
       post '/api/v2/users/', user_with_no_name.to_json
       expect(last_response.status).to eq(400)


### PR DESCRIPTION
This is not yet fully tested with the User Management module. Queries
are still open, as well as returning data from creation (e.g., the
token used authenticate users later in the process)