### PR TITLE
Fix a bug introduced when /functions are searched.

### DIFF
--- a/son-gtkapi/routes/request.rb
+++ b/son-gtkapi/routes/request.rb
@@ -71,7 +71,7 @@ class GtkApi < Sinatra::Base
       logger.debug(MESSAGE) {"requests = #{requests}"}
       if requests
         links = build_pagination_headers(url: request_url, limit: @limit.to_i, offset: @offset.to_i, total: requests[:count])
-        headers 'Link' => links, 'Record-Count' => requests[:count].to_s
+        headers 'Link' => links, 'Record-Count' => requests[:count].to_s, 'Content-Type'=>'application/json'
         halt 200, requests[:items].to_json
       else
         ERROR_MESSAGE = 'No requests with '+query_string+' were found'

--- a/son-gtksrv/models/v_function.rb
+++ b/son-gtksrv/models/v_function.rb
@@ -33,14 +33,19 @@ class VFunction
   end
   
   def find_function(name,vendor,version)
+    log_message = 'VFunction.'+__method__.to_s
     headers = { 'Accept'=> 'application/json', 'Content-Type'=>'application/json'}
     url = @catalogue.url+"?name=#{name}&vendor=#{vendor}&version=#{version}"
+    @logger.debug(log_message) {"url="+url}
     begin
       response = RestClient.get(url, headers)
-      function=JSON.parse response.body
-      function['vnfd']
+      body = response.body
+      @logger.debug(log_message) {"body=#{body}"}
+      function=JSON.parse(body, symbolize_names: true)
+      @logger.debug(log_message) {"function=#{function}"}
+      function[0][:vnfd]
     rescue => e
-      @logger.error "No function found for "+url
+      @logger.error(log_message) {"No function found for "+url}
       e.message
     end
   end

--- a/son-gtksrv/routes/request.rb
+++ b/son-gtksrv/routes/request.rb
@@ -62,7 +62,7 @@ class GtkSrv < Sinatra::Base
     json_requests = json(requests, { root: false })
     logger.info(MODULE) {" leaving GET /requests?#{query_string} with "+json_requests}
     if json_requests
-      headers 'Record-Count'=>requests.size.to_s
+      headers 'Record-Count'=>requests.size.to_s, 'Content-Type'=>'application/json'
       halt 200, json_requests
     end
     json_error 404, 'GtkSrv: No requests were found'
@@ -91,7 +91,7 @@ class GtkSrv < Sinatra::Base
         start_request['NSD']=service #['nsd']
       
         service['network_functions'].each_with_index do |function, index|
-          logger.debug(log_msg) { "function=[#{function['vnf_name']}, #{function['vnf_vendor']}, #{function['vnf_version']}]"}
+          logger.debug(log_msg) { "function=['#{function['vnf_name']}', '#{function['vnf_vendor']}', '#{function['vnf_version']}']"}
           vnfd = VFunction.new(settings.functions_catalogue, logger).find_function(function['vnf_name'],function['vnf_vendor'],function['vnf_version'])
           logger.debug(log_msg) {"function#{index}=#{vnfd}"}
           if vnfd[0]


### PR DESCRIPTION
An array of fucntions is returned, even if the result is one function
only, and it includes meta-data.