### PR TITLE
Replaces several routes' before block with an options route

### DIFF
--- a/son-gtkapi/models/kpi_manager_service.rb
+++ b/son-gtkapi/models/kpi_manager_service.rb
@@ -59,13 +59,34 @@ class KpiManagerService < ManagerService
     end      
   end
 
+  def self.find(params)
+    method = LOG_MESSAGE + "##{__method__}"
+    GtkApi.logger.debug(method) {"entered with params=#{params}"}
+    GtkApi.logger.debug(method) {"url = "+@@url}
+
+    # POST .../api/v1/prometheus/metrics/data with body {"name":"user_registrations","start": "2017-05-03T11:41:22Z", "end": "2017-05-03T11:51:11Z", "step": "10s", "labels":[]}    
+    begin
+      response = postCurb(url: @@url+'/kpis', params: params)      
+      case response[:status]
+      when 200
+        { status: response[:status], data: JSON.parse(response[:items].to_json, :symbolize_names => true) }
+      else
+        { status: response[:status], data: {}, message: 'Metric does not retrieved'}
+      end   
+    rescue => e
+      GtkApi.logger.error(method) {"Error during processing: #{$!}"}
+      GtkApi.logger.error(method) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"}
+      { status: 500, message: e.backtrace.join("\n\t")}
+    end      
+  end
+
   def self.get_metric(params)
     method = LOG_MESSAGE + "##{__method__}(#{params})"
     GtkApi.logger.debug(method) {"entered"}
     
     begin
       GtkApi.logger.debug(method) {"url = "+@@url}
-      response = getCurb(url: @@url+'/kpis', params: params, headers:JSON_HEADERS)      
+      response = getCurb(url: @@url+'/original-kpis', params: params, headers:JSON_HEADERS)      
       case response[:status]
       when 200
         { status: response[:status], data: JSON.parse(response[:items].to_json, :symbolize_names => true) }

--- a/son-gtkapi/models/record_manager_service.rb
+++ b/son-gtkapi/models/record_manager_service.rb
@@ -56,7 +56,7 @@ class RecordManagerService < ManagerService
     find(url: @@url + '/' + kind + '/' + uuid, log_message: LOG_MESSAGE + "##{__method__}(#{uuid})") #+ '/records/' 
   end
   
-  def find_records_by_function_uuid(uuid)
+  def self.find_records_by_function_uuid(uuid)
     method = LOG_MESSAGE + "##{__method__}"
     GtkApi.logger.debug(method) {"entered with uuid=#{uuid}"}
     find(url: @@url + '/functions?function_uuid=' + uuid, log_message: LOG_MESSAGE + "##{__method__}(#{uuid})") #+ '/records/' 

--- a/son-gtkapi/models/user.rb
+++ b/son-gtkapi/models/user.rb
@@ -232,6 +232,7 @@ class User < ManagerService
       GtkApi.logger.debug(method) {"Got response: #{response}"}
       case response[:status]
       when 200
+        GtkApi.logger.debug(method) {'response[:items].empty? '+(response[:items].empty? ? 'yes' : 'no')}
         raise UsersNotFoundError.new "No users with params #{params} were found" if response[:items].empty?
         retrieved_users = []
         response[:items].each do |user|
@@ -243,10 +244,10 @@ class User < ManagerService
       else 
         raise UsersNotFoundError.new "Users with params #{params} were not found(code #{response[:code]})"
       end
-    rescue => e
+    rescue StandardError => e
       GtkApi.logger.error(method) {"Error during processing: #{$!}"}
       GtkApi.logger.error(method) {"Backtrace:\n\t#{e.backtrace.join("\n\t")}"}
-      nil
+      []
     end
   end
   

--- a/son-gtkapi/routes/licence.rb
+++ b/son-gtkapi/routes/licence.rb
@@ -29,19 +29,16 @@ require 'sinatra/namespace'
 class GtkApi < Sinatra::Base
   
   register Sinatra::Namespace
-  namespace '/api/v2' do
-    #options '/' do
-    before do
-      if request.request_method == 'OPTIONS'
-        response.headers['Access-Control-Allow-Origin'] = '*'
-        response.headers['Access-Control-Allow-Methods'] = 'POST,PUT'      
-        response.headers['Access-Control-Allow-Headers'] = 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
-        halt 200
-      end
+  namespace '/api/v2/licences' do
+    options '/?' do
+      response.headers['Access-Control-Allow-Origin'] = '*'
+      response.headers['Access-Control-Allow-Methods'] = 'POST,PUT'      
+      response.headers['Access-Control-Allow-Headers'] = 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
+      halt 200
     end
 
     # GET many licences
-    get '/licences/?' do
+    get '/?' do
       # TODO
       log_message = 'GtkApi::GET /api/v2/licences/?'
     
@@ -68,7 +65,7 @@ class GtkApi < Sinatra::Base
     end
 
     # GET a specific licence
-    get '/licences/:uuid/?' do
+    get '/:uuid/?' do
       log_message = MODULE+' GET /api/v2/licences/:uuid'
       logger.debug(log_message) {"entered with #{params[:uuid]}"}
     
@@ -88,7 +85,7 @@ class GtkApi < Sinatra::Base
       end
     end
     
-    post '/licences/?' do
+    post '/?' do
       log_message = 'GtkApi::POST /licences/?'
       body = request.body.read
       

--- a/son-gtkapi/routes/record.rb
+++ b/son-gtkapi/routes/record.rb
@@ -31,14 +31,12 @@ class GtkApi < Sinatra::Base
   register Sinatra::Namespace
   
   namespace '/api/v2/records' do
-    before do
-      if request.request_method == 'OPTIONS'
-        response.headers['Access-Control-Allow-Origin'] = '*'
-        response.headers['Access-Control-Allow-Methods'] = 'POST,PUT'      
-        response.headers['Access-Control-Allow-Headers'] = 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
-        halt 200
-      end
-  	end
+    options '/?' do
+      response.headers['Access-Control-Allow-Origin'] = '*'
+      response.headers['Access-Control-Allow-Methods'] = 'POST,PUT'      
+      response.headers['Access-Control-Allow-Headers'] = 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
+      halt 200
+    end
 
     # GET many instances
     get '/:kind/?' do

--- a/son-gtkapi/routes/request.rb
+++ b/son-gtkapi/routes/request.rb
@@ -31,13 +31,11 @@ class GtkApi < Sinatra::Base
   register Sinatra::Namespace
   
   namespace '/api/v2/requests' do  
-    before do
-      if request.request_method == 'OPTIONS'
-        response.headers['Access-Control-Allow-Origin'] = '*'
-        response.headers['Access-Control-Allow-Methods'] = 'POST,PUT'      
-        response.headers['Access-Control-Allow-Headers'] = 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
-        halt 200
-      end
+    options '/?' do
+      response.headers['Access-Control-Allow-Origin'] = '*'
+      response.headers['Access-Control-Allow-Methods'] = 'POST,PUT'      
+      response.headers['Access-Control-Allow-Headers'] = 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
+      halt 200
     end
   
     # POST a request

--- a/son-gtkapi/routes/service.rb
+++ b/son-gtkapi/routes/service.rb
@@ -32,16 +32,13 @@ class GtkApi < Sinatra::Base
   helpers GtkApiHelper
   
   namespace '/api/v2/services' do
-    #options '/' do
-    before do
-      if request.request_method == 'OPTIONS'
-        response.headers['Access-Control-Allow-Origin'] = '*'
-        response.headers['Access-Control-Allow-Methods'] = 'POST,PUT'      
-        response.headers['Access-Control-Allow-Headers'] = 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
-        halt 200
-      end
+    options '/?' do
+      response.headers['Access-Control-Allow-Origin'] = '*'
+      response.headers['Access-Control-Allow-Methods'] = 'POST,PUT'      
+      response.headers['Access-Control-Allow-Headers'] = 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
+      halt 200
     end
-    
+
     # GET many services
     get '/?' do
       log_message = 'GtkApi:: GET /api/v2/services'    

--- a/son-gtkapi/routes/sessions_controller.rb
+++ b/son-gtkapi/routes/sessions_controller.rb
@@ -33,13 +33,11 @@ class GtkApi < Sinatra::Base
   helpers GtkApiHelper
   
   namespace '/api/v2/sessions' do
-    before do
-      if request.request_method == 'OPTIONS'
-        response.headers['Access-Control-Allow-Origin'] = '*'
-        response.headers['Access-Control-Allow-Methods'] = 'POST,DELETE'      
-        response.headers['Access-Control-Allow-Headers'] = 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
-        halt 200
-      end
+    options '/?' do
+      response.headers['Access-Control-Allow-Origin'] = '*'
+      response.headers['Access-Control-Allow-Methods'] = 'POST,DELETE'      
+      response.headers['Access-Control-Allow-Headers'] = 'Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With'
+      halt 200
     end
     
     # AKA login


### PR DESCRIPTION
We had this before block, and it was not working on every situation (we had always 'POST,PUT' as the `Access-Control-Allow-Methods` returned, instead of the ones we defined).