### PR TITLE
Add time_stamp to the API

### DIFF
--- a/son-gtkapi/routes/package.rb
+++ b/son-gtkapi/routes/package.rb
@@ -79,28 +79,35 @@ class GtkApi < Sinatra::Base
         case resp[:status]
         when 201
           logger.info(log_message) {"leaving with package: #{resp[:data][:uuid]}"}
-          count_package_on_boardings(labels: {result: "ok", uuid: resp[:data][:uuid], elapsed_time: (Time.now.utc-began_at).to_s})
+          now = Time.now.utc
+          count_package_on_boardings(labels: {result: "ok", uuid: resp[:data][:uuid], elapsed_time: (now-began_at).to_s, time_stamp: now})
           headers 'Location'=> PackageManagerService.class_variable_get(:@@url)+"/packages/#{resp[:data][:uuid]}", 'Content-Type'=> 'application/json'
           halt 201, resp[:data].to_json
         when 400
-          count_package_on_boardings(labels: {result: "bad request", uuid: '', elapsed_time: (Time.now.utc-began_at).to_s})
+          count_package_on_boardings(labels: {result: "bad request", uuid: '', elapsed_time: (now-began_at).to_s, time_stamp: now})
+          now = Time.now.utc
           json_error 400, "Error creating package #{params}", log_message
         when 403
-          count_package_on_boardings(labels: {result: "forbidden", uuid: '', elapsed_time: (Time.now.utc-began_at).to_s})
+          count_package_on_boardings(labels: {result: "forbidden", uuid: '', elapsed_time: (now-began_at).to_s, time_stamp: now})
+          now = Time.now.utc
           json_error 403, "User not allowed to create package #{params}", log_message
         when 404
-          count_package_on_boardings(labels: {result: "not found", uuid: '', elapsed_time: (Time.now.utc-began_at).to_s})
+          count_package_on_boardings(labels: {result: "not found", uuid: '', elapsed_time: (now-began_at).to_s, time_stamp: now})
+          now = Time.now.utc
           json_error 404, "User name not found", log_message
         when 409
           logger.error(log_message) {"leaving with duplicated package: #{resp[:data]}"}
-          count_package_on_boardings(labels: {result: "duplicated", uuid: resp[:data][:uuid], elapsed_time: (Time.now.utc-began_at).to_s})
+          now = Time.now.utc
+          count_package_on_boardings(labels: {result: "duplicated", uuid: resp[:data][:uuid], elapsed_time: (now-began_at).to_s, time_stamp: now})
           halt 409, resp[:data].to_json
         else
-          count_package_on_boardings(labels: {result: "other error", uuid: '', elapsed_time: (Time.now.utc-began_at).to_s})
+          now = Time.now.utc
+          count_package_on_boardings(labels: {result: "other error", uuid: '', elapsed_time: (now-began_at).to_s, time_stamp: now})
           json_error resp[:status], "Unknown status: #{resp[:status]} for package #{params}", log_message
         end
       rescue ArgumentError => e
-        count_package_on_boardings(labels: {result: "bad request", uuid: '', elapsed_time: (Time.now.utc-began_at).to_s})
+        now = Time.now.utc
+        count_package_on_boardings(labels: {result: "bad request", uuid: '', elapsed_time: (now-began_at).to_s, time_stamp: now})
         json_error 400, "Error creating package #{params}", log_message
       end
     end


### PR DESCRIPTION
In order for the GUI to be able to show this data along a 'time' axes, a `time_stamp` is needed on every KPI report