### PR TITLE
Changed monitoring data endpooint

### DIFF
--- a/son-gtkapi/routes/metrics_controller.rb
+++ b/son-gtkapi/routes/metrics_controller.rb
@@ -35,10 +35,10 @@ class GtkApi < Sinatra::Base
     # TODO: how to address multiple metrics like in
     # .../metric=cpu_util,disk_usage,packets_sent&...
     
-    # GET /functions/instances/:instance_uuid/asynch-mon-data?metric=cpu_util&since=…&until=…
-    get '/instances/:instance_uuid/asynch-mon-data/?' do
+    # GET Asynchronous data request
+    get '/metrics/:instance_uuid/:vdu_id/:vnfc_uuid/asynch-mon-data/?' do
       began_at = Time.now.utc
-      log_message = 'GtkApi::GET /api/v2/functions/instances/:instance_uuid/asynch-mon-data/?'
+      log_message = 'GtkApi::GET /api/v2/functions/instances/:instance_uuid/:vdu_id/:vnfc_uuid/asynch-mon-data/?'
       logger.debug(log_message) {"entered with params #{params}"}
       
       content_type :json
@@ -48,32 +48,25 @@ class GtkApi < Sinatra::Base
       params.delete('captures')
       params.merge(parse_query_string(request.env['QUERY_STRING']))
       
+      require_param(param: 'instance_uuid', params: params, error_message: 'Function instance uuid', log_message: log_message, began_at: began_at)
+      require_param(param: 'vdu_id', params: params, error_message: 'VDU id', log_message: log_message, began_at: began_at)
+      require_param(param: 'vnfc_uuid', params: params, error_message: 'VNFC instance uuid', log_message: log_message, began_at: began_at)
+      require_param(param: 'metrics', params: params, error_message: 'Metrics list', log_message: log_message, began_at: began_at)
+      require_param(param: 'since', params: params, error_message: 'Starting date', log_message: log_message, began_at: began_at)
+      require_param(param: 'until', params: params, error_message: 'Ending date', log_message: log_message, began_at: began_at)
+      require_param(param: 'step', params: params, error_message: 'Step of collection', log_message: log_message, began_at: began_at)
+       
       token = get_token( request.env, log_message)
       if (token.nil? || token.empty?)
         count_synch_monitoring_data_requests(labels: {result: "bad request", uuid: '', elapsed_time: (Time.now.utc-began_at).to_s})
         json_error 400, 'A valid user access token was not provided', log_message
       end
       
-      unless User.authorized?(token: token, params: {path: '/functions/instances', method: 'GET'})
+      unless User.authorized?(token: token, params: {path: '/functions/metrics', method: 'GET'})
         count_service_metadata_queries(labels: {result: "forbidden", uuid: params[:instance_uuid], elapsed_time: (Time.now.utc-began_at).to_s})
         json_error 403, "Forbidden: user could not be authorized to request asynch monitorin data for function instance #{params[:instance_uuid]}", log_message
       end
       
-      unless (params.key?('metrics') && !params['metrics'].empty?)
-        count_synch_monitoring_data_requests(labels: {result: "bad request", uuid: '', elapsed_time: (Time.now.utc-began_at).to_s})
-        json_error 400, 'Metrics list is missing', log_message
-      end
-      
-      unless (params.key?('since') && !params['since'].empty?)
-        count_synch_monitoring_data_requests(labels: {result: "bad request", uuid: '', elapsed_time: (Time.now.utc-began_at).to_s})
-        json_error 400, 'Starting date is missing', log_message
-      end
-      
-      unless (params.key?('until') && !params['until'].empty?)
-        count_synch_monitoring_data_requests(labels: {result: "bad request", uuid: '', elapsed_time: (Time.now.utc-began_at).to_s})
-        json_error 400, 'Ending date is missing', log_message
-      end
-       
       # Remove list of wanted fields from the query parameter list
       metrics_names = params.delete('metrics').split(',')
       logger.debug(log_message) { "params without metrics=#{params}"}
@@ -85,6 +78,7 @@ class GtkApi < Sinatra::Base
       
       metrics = Metric.validate_and_create(metrics_names)
       status = nil
+      requested_data = []
         
       # TODO: we're assuming this is treated one metric at a time
       metrics.each do |metric|
@@ -92,10 +86,11 @@ class GtkApi < Sinatra::Base
         begin
           resp = metric.asynch_monitoring_data({
             start: params[:since].to_s, end: params[:until].to_s,
-            step: params[:step], instance_id: params[:instance_uuid]
+            step: params[:step], vnfc_id: params[:vnfc_uuid]
           })
           # In the end, :status will be the one of the last metric processed
           status = resp[:status]
+          requested_data << resp
         rescue AsynchMonitoringDataRequestNotCreatedError
           logger.debug(log_message) {'Failled request with params '+params.to_s+ ' for metric '+metric.name}
           next
@@ -105,21 +100,20 @@ class GtkApi < Sinatra::Base
       return_data = {
         status: status,
         function_instance_uuid: params[:instance_uuid],
-        metrics: metrics_names #,
-        #ws_url: ws_url
+        vdu_id: params[:vdu_id],
+        vnfc_uuid: params[:vnfc_uuid],
+        metrics: metrics_names,
+        requested_data: requested_data
       }
       logger.debug(log_message) {"Leaving with #{return_data}"}
       halt 200, return_data.to_json
     end
     
-    # …/functions/instances/:instance_uuid/synch-mon-data?metrics=cpu_util&for=<number of seconds>
-    # this was
-    # …/functions/:function_uuid/instances/:instance_uuid/synch-mon-data?metrics=cpu_util&for=<number of seconds>
-    get '/instances/:instance_uuid/synch-mon-data/?' do
+    # GET synchronous data request
+    get '/metrics/:instance_uuid/:vdu_id/:vnfc_uuid/synch-mon-data/?' do
       began_at = Time.now.utc
-      log_message = 'GtkApi::GET /api/v2/functions/:uuid/instances/:instance_uuid/synch-mon-data/?'
-      logger.debug(log_message) {"entered with function instance #{params[:instance_uuid]}"}
-      # {"metric":"vm_cpu_perc","filters":["id='123456asdas255sdas'","type='vnf'"]}
+      log_message = 'GtkApi::GET /api/v2/functions/metrics/:instance_uuid/:vdu_id/:vnfc_uuid/synch-mon-data/?'
+      logger.debug(log_message) {"entered with params #{params}"}
       
       content_type :json
       
@@ -128,31 +122,22 @@ class GtkApi < Sinatra::Base
       params.delete('captures')
       params.merge(parse_query_string(request.env['QUERY_STRING']))
       
+      require_param(param: 'instance_uuid', params: params, error_message: 'Function instance uuid', log_message: log_message, began_at: began_at)
+      require_param(param: 'vdu_id', params: params, error_message: 'VDU id', log_message: log_message, began_at: began_at)
+      require_param(param: 'vnfc_uuid', params: params, error_message: 'VNFC instance uuid', log_message: log_message, began_at: began_at)
+      require_param(param: 'metrics', params: params, error_message: 'Metrics list ', log_message: log_message, began_at: began_at)
+
       token = get_token( request.env, log_message)
       if (token.nil? || token.empty?)
         count_synch_monitoring_data_requests(labels: {result: "bad request", uuid: '', elapsed_time: (Time.now.utc-began_at).to_s})
         json_error 400, 'A valid user access token was not provided', log_message
       end
       
-      unless (params.key?('metrics') && !params['metrics'].empty?)
-        count_synch_monitoring_data_requests(labels: {result: "bad request", uuid: '', elapsed_time: (Time.now.utc-began_at).to_s})
-        json_error 400, 'Metrics list is missing', log_message
+      unless User.authorized?(token: token, params: {path: '/functions/metrics', method: 'GET'})
+        count_service_metadata_queries(labels: {result: "forbidden", uuid: params[:instance_uuid], elapsed_time: (Time.now.utc-began_at).to_s})
+        json_error 403, "Forbidden: user could not be authorized to request asynch monitorin data for function instance #{params[:instance_uuid]}", log_message
       end
        
-      # TODO: duration is not yet being treated
-      # json_error 400, 'Duration is missing' unless (params.key?(:for) && !params[:for].empty?)
-      # Can we fix the ID as being function instance ID...
-      # json_error 400, 'ID is missing' unless (params.key?(:id) && !params[:id].empty?)
-      # ...and type as being 'vnf'?
-      # json_error 400, 'Type is missing' unless (params.key?(:type) && !params[:type].empty?)
-    
-      #begin
-      #  function = FunctionManagerService.find_by_uuid!(params[:uuid])
-      #rescue FunctionNotFoundError
-      #  count_synch_monitoring_data_requests(labels: {result: "not found", uuid: '', elapsed_time: (Time.now.utc-began_at).to_s})
-      #  json_error 404, "Function #{params[:uuid]} not found", log_message
-      #end
-    
       # do not treat 'for=<length in seconds> now
       unless params['for'].to_s.empty?
         logger.debug(log_message) {"Currently we're not processing the 'for=<length in seconds>' parameter"}
@@ -168,8 +153,6 @@ class GtkApi < Sinatra::Base
         count_synch_monitoring_data_requests(labels: {result: "not found", uuid: '', elapsed_time: (Time.now.utc-began_at).to_s})
         json_error 404, "At least one metric must be given", log_message
       end
-
-      #function.load_instances(params[:uuid])
       
       metrics = Metric.validate_and_create(metrics_names)
       ws_url = ''
@@ -179,7 +162,7 @@ class GtkApi < Sinatra::Base
       metrics.each do |metric|
         logger.debug(log_message) { "Metric: #{metric.inspect}"}
         begin
-          resp = metric.synch_monitoring_data(params[:instance_uuid])
+          resp = metric.synch_monitoring_data(params[:vnfc_uuid])
           # {"status": "SUCCESS","metric": [<metric_name1>,<matric_name2>], "ws_url":"ws://<ws_server_ip>:8002/ws/<ws_id>"}
           # In the end, :status and :ws_url will be the ones of the last metric processed
           ws_url = resp[:ws_url]
@@ -223,5 +206,12 @@ class GtkApi < Sinatra::Base
     name = __method__.to_s.split('_')[1..-1].join('_')
     desc = "how many synch monitoring data requests have been made"
     Metric.counter_kpi({name: name, docstring: desc, base_labels: labels.merge({method: 'GET', module: 'metrics'})})
+  end
+  
+  def require_param(param:, params:, error_message:, log_message:, began_at:)
+    if (!params.key?(param) || params[param].empty?)
+      count_synch_monitoring_data_requests(labels: {result: "bad request", uuid: '', elapsed_time: (Time.now.utc-began_at).to_s})
+      json_error 400, error_message+' is missing', log_message
+    end 
   end
 end


### PR DESCRIPTION
For either synchronous or asynchronous data requests, the endpoint now
is `/functions/metrics/:instance_uuid/:vdu_id/:vnfc_uuid`