### PR TITLE
Refactor POSTing the package to the validator

### DIFF
--- a/son-gtkapi/models/validator.rb
+++ b/son-gtkapi/models/validator.rb
@@ -53,7 +53,7 @@ class Validator < ManagerService
     # prepare post data
     fields_hash = {source:'embedded', syntax: true, integrity: true, topology: true, signature: signature}
     post_data = fields_hash.map { |k, v| Curl::PostField.content(k, v.to_s) }
-    post_data << Curl::PostField.file('file', file_name), 
+    post_data << Curl::PostField.file('file', file_name)
 
     begin
       # post

--- a/son-gtkapi/routes/package.rb
+++ b/son-gtkapi/routes/package.rb
@@ -60,11 +60,10 @@ class GtkApi < Sinatra::Base
       end
 
       signature = get_signature( request.env, log_message)
-      file = params[:package][:tempfile].read
-      GtkApi.logger.error(log_message) {"file content is #{file}"}
+      GtkApi.logger.error(log_message) {"file name is #{params[:package][:tempfile]}"}
       begin
         # Validate validator's existence first here
-        Validator.valid_package?(file_content: file, signature: signature)
+        Validator.valid_package?(file_name: params[:package][:tempfile], signature: signature)
       rescue ValidatorError => e
         count_package_on_boardings(labels: {result: "bad request", uuid: '', elapsed_time: (Time.now.utc-began_at).to_s})
         json_error 400, "Error creating package #{params}", log_message


### PR DESCRIPTION
`Curb` needs the file name, not its content. Translation from parameters to `Curl::PostField` was also improved