### PR TITLE
Adds start-up time and life (in seconds) to the available micro-services

### DIFF
--- a/son-gtkapi/models/function_manager_service.rb
+++ b/son-gtkapi/models/function_manager_service.rb
@@ -98,5 +98,13 @@ class FunctionManagerService < ManagerService
       @instances = nil
     end
   end
+  
+  def self.began_at
+    log_message=LOG_MESSAGE+"##{__method__}"
+    GtkApi.logger.debug(log_message) {'entered'}    
+    response = getCurb(url: @@url + '/began_at')
+    GtkApi.logger.debug(log_message) {"response=#{response}"}
+    response
+  end
 end
 

--- a/son-gtkapi/models/kpi_manager_service.rb
+++ b/son-gtkapi/models/kpi_manager_service.rb
@@ -102,4 +102,12 @@ class KpiManagerService < ManagerService
       { status: 500, message: e.backtrace.join("\n\t")}
     end      
   end
+  
+  def self.began_at
+    log_message=LOG_MESSAGE+"##{__method__}"
+    GtkApi.logger.debug(log_message) {'entered'}    
+    response = getCurb(url: @@url + '/began_at')
+    GtkApi.logger.debug(log_message) {"response=#{response}"}
+    response
+  end
 end

--- a/son-gtkapi/models/licence_manager_service.rb
+++ b/son-gtkapi/models/licence_manager_service.rb
@@ -114,6 +114,14 @@ class LicenceManagerService < ManagerService
     end
   end
   
+  def self.began_at
+    log_message=LOG_MESSAGE+"##{__method__}"
+    GtkApi.logger.debug(log_message) {'entered'}    
+    response = getCurb(url: @@url + '/began_at')
+    GtkApi.logger.debug(log_message) {"response=#{response}"}
+    response
+  end
+  
   #def user
   #  @user ||= User.find(params[:user_id]) || halt(404)
   #end

--- a/son-gtkapi/models/metric.rb
+++ b/son-gtkapi/models/metric.rb
@@ -211,5 +211,13 @@ class Metric < ManagerService
     GtkApi.logger.debug(log_message) {"exiting with metrics=#{metrics}"}
     metrics
   end
+  
+  def self.began_at
+    log_message=LOG_MESSAGE+"##{__method__}"
+    GtkApi.logger.debug(log_message) {'entered'}    
+    response = getCurb(url: @@url + '/began_at')
+    GtkApi.logger.debug(log_message) {"response=#{response}"}
+    response
+  end
 end
   

--- a/son-gtkapi/models/micro_service.rb
+++ b/son-gtkapi/models/micro_service.rb
@@ -149,4 +149,12 @@ class MicroService < ManagerService
       raise PublicKeyNotFoundError.new('No public key received from User Management micro-service')
     end
   end
+  
+  def self.began_at
+    log_message=LOG_MESSAGE+"##{__method__}"
+    GtkApi.logger.debug(log_message) {'entered'}    
+    response = getCurb(url: @@url + '/began_at')
+    GtkApi.logger.debug(log_message) {"response=#{response}"}
+    response
+  end
 end

--- a/son-gtkapi/models/package.rb
+++ b/son-gtkapi/models/package.rb
@@ -242,4 +242,12 @@ class Package < ManagerService
   def is_licensed?(user_id)
   end
   
+  def self.began_at
+    log_message=LOG_MESSAGE+"##{__method__}"
+    GtkApi.logger.debug(log_message) {'entered'}    
+    response = getCurb(url: @@url + '/began_at')
+    GtkApi.logger.debug(log_message) {"response=#{response}"}
+    response
+  end
+  
 end

--- a/son-gtkapi/models/rate_limiter.rb
+++ b/son-gtkapi/models/rate_limiter.rb
@@ -28,7 +28,7 @@
 require './models/manager_service.rb'
 require 'active_support'
 
-class Throttle < ManagerService
+class RateLimiter < ManagerService
 
   LOG_MESSAGE = 'GtkApi::' + self.name
   
@@ -44,6 +44,7 @@ class Throttle < ManagerService
     GtkApi.logger.debug(method) {'entered with url='+url}
   end
   
+  # TODO: adapt all this to the true Rate Limiter
   def self.open?(params)
     method = LOG_MESSAGE + __method__.to_s
     GtkApi.logger.debug(method) {"entered with params=#{params}"}

--- a/son-gtkapi/models/record_manager_service.rb
+++ b/son-gtkapi/models/record_manager_service.rb
@@ -61,4 +61,12 @@ class RecordManagerService < ManagerService
     GtkApi.logger.debug(method) {"entered with uuid=#{uuid}"}
     find(url: @@url + '/functions?function_uuid=' + uuid, log_message: LOG_MESSAGE + "##{__method__}(#{uuid})") #+ '/records/' 
   end
+  
+  def self.began_at
+    log_message=LOG_MESSAGE+"##{__method__}"
+    GtkApi.logger.debug(log_message) {'entered'}    
+    response = getCurb(url: @@url + '/began_at')
+    GtkApi.logger.debug(log_message) {"response=#{response}"}
+    response
+  end
 end

--- a/son-gtkapi/models/service_manager_service.rb
+++ b/son-gtkapi/models/service_manager_service.rb
@@ -128,6 +128,14 @@ class ServiceManagerService < ManagerService
     end      
   end
   
+  def self.began_at
+    log_message=LOG_MESSAGE+"##{__method__}"
+    GtkApi.logger.debug(log_message) {'entered'}    
+    response = getCurb(url: @@url + '/began_at')
+    GtkApi.logger.debug(log_message) {"response=#{response}"}
+    response
+  end
+  
   # TODO
   def self.valid?(service_uuid)
     message = LOG_MESSAGE+"##{__method__}"

--- a/son-gtkapi/models/user.rb
+++ b/son-gtkapi/models/user.rb
@@ -206,6 +206,9 @@ class User < ManagerService
         GtkApi.logger.debug(log_message) {"user does not respond to #{setter}"}
       end
     end
+    
+    # TODO
+    # what about actualy updating in the USer Managemen??
   end
   
 =begin
@@ -384,6 +387,14 @@ class User < ManagerService
     method = LOG_MESSAGE + "##{__method__}"
     GtkApi.logger.debug(method) {"entered"}
     self.instance_variables.each_with_object({}) { |var,hash| hash[var[1..-1].to_sym] = self.instance_variable_get(var) }
+  end
+  
+  def self.began_at
+    log_message=LOG_MESSAGE+"##{__method__}"
+    GtkApi.logger.debug(log_message) {'entered'}    
+    response = getCurb(url: @@url + '/began_at')
+    GtkApi.logger.debug(log_message) {"response=#{response}"}
+    response
   end
   
   private 

--- a/son-gtkapi/models/validator.rb
+++ b/son-gtkapi/models/validator.rb
@@ -88,4 +88,12 @@ class Validator < ManagerService
       raise ValidatorGenericError.new "There was a problem POSTing a package file to the Package validator"
     end    
   end
+  
+  def self.began_at
+    log_message=LOG_MESSAGE+"##{__method__}"
+    GtkApi.logger.debug(log_message) {'entered'}    
+    response = getCurb(url: @@url + '/began_at')
+    GtkApi.logger.debug(log_message) {"response=#{response}"}
+    response
+  end
 end

--- a/son-gtkapi/models/vim_manager_service.rb
+++ b/son-gtkapi/models/vim_manager_service.rb
@@ -222,4 +222,12 @@ class VimManagerService < ManagerService
       nil
     end
   end
+  
+  def self.began_at
+    log_message=LOG_MESSAGE+"##{__method__}"
+    GtkApi.logger.debug(log_message) {'entered'}    
+    response = getCurb(url: @@url + '/began_at')
+    GtkApi.logger.debug(log_message) {"response=#{response}"}
+    response
+  end
 end

--- a/son-gtkapi/models/vim_manager_service.rb
+++ b/son-gtkapi/models/vim_manager_service.rb
@@ -232,4 +232,3 @@ class VimManagerService < ManagerService
     response
   end
 end
-end

--- a/son-gtkapi/models/wim_manager_service.rb
+++ b/son-gtkapi/models/wim_manager_service.rb
@@ -89,4 +89,12 @@ class WimManagerService < ManagerService
       nil
     end
   end
+  
+  def self.began_at
+    log_message=LOG_MESSAGE+"##{__method__}"
+    GtkApi.logger.debug(log_message) {'entered'}    
+    response = getCurb(url: @@url + '/began_at')
+    GtkApi.logger.debug(log_message) {"response=#{response}"}
+    response
+  end
 end

--- a/son-gtkfnct/routes/function.rb
+++ b/son-gtkfnct/routes/function.rb
@@ -82,6 +82,13 @@ class GtkFnct < Sinatra::Base
     File.open('log/'+ENV['RACK_ENV']+'.log', 'r').read
   end
   
+  get '/began_at/?' do
+    log_message = 'GtkFnct GET /began_at'
+    logger.debug(log_message) {'entered'}
+    logger.debug(log_message) {"began at #{settings.began_at}"}
+    halt 200, {began_at: settings.began_at}.to_json
+  end
+  
   private
     
   def query_string

--- a/son-gtkkpi/routes/request.rb
+++ b/son-gtkkpi/routes/request.rb
@@ -198,4 +198,11 @@ class GtkKpi < Sinatra::Base
     logger.debug(log_message) {"entered"}
     File.open('log/'+ENV['RACK_ENV']+'.log', 'r').read
   end
+  
+  get '/began_at/?' do
+    log_message = 'GtkKpi GET /began_at'
+    logger.debug(log_message) {'entered'}
+    logger.debug(log_message) {"began at #{settings.began_at}"}
+    halt 200, {began_at: settings.began_at}.to_json
+  end
 end

--- a/son-gtkpkg/routes/package.rb
+++ b/son-gtkpkg/routes/package.rb
@@ -159,4 +159,11 @@ class GtkPkg < Sinatra::Base
     logger.debug "GtkPkg: entered GET /admin/logs"
     File.open('log/'+ENV['RACK_ENV']+'.log', 'r').read
   end
+  
+  get '/began_at/?' do
+    log_message = LOG_MESSAGE + ' /began_at'
+    logger.debug(log_message) {'entered'}
+    logger.debug(log_message) {"began at #{settings.began_at}"}
+    halt 200, {began_at: settings.began_at}.to_json
+  end
 end

--- a/son-gtkrec/routes/service.rb
+++ b/son-gtkrec/routes/service.rb
@@ -83,6 +83,13 @@ class GtkRec < Sinatra::Base
     File.open('log/'+ENV['RACK_ENV']+'.log', 'r').read
   end  
   
+  get '/began_at/?' do
+    log_message = 'GtkRec GET /began_at'
+    logger.debug(log_message) {'entered'}
+    logger.debug(log_message) {"began at #{settings.began_at}"}
+    halt 200, {began_at: settings.began_at}.to_json
+  end
+  
   private 
   def query_string
     request.env['QUERY_STRING'].nil? ? '' : '?' + request.env['QUERY_STRING'].to_s

--- a/son-gtksrv/routes/request.rb
+++ b/son-gtksrv/routes/request.rb
@@ -139,6 +139,13 @@ class GtkSrv < Sinatra::Base
     logger.debug(log_message) {"returning with updated request=#{request}"}
     halt 200, request.to_json
   end  
+  
+  get '/began_at/?' do
+    log_message = 'GtkSrv GET /began_at'
+    logger.debug(log_message) {'entered'}
+    logger.debug(log_message) {"began at #{settings.began_at}"}
+    halt 200, {began_at: settings.began_at}.to_json
+  end
 
   private 
   def query_string
@@ -146,13 +153,13 @@ class GtkSrv < Sinatra::Base
   end
 
   def request_url
-    log_message = 'GtkApi::request_url'
+    log_message = 'GtkSrv::request_url'
     logger.debug(log_message) {"Schema=#{request.env['rack.url_scheme']}, host=#{request.env['HTTP_HOST']}, path=#{request.env['REQUEST_PATH']}"}
     request.env['rack.url_scheme']+'://'+request.env['HTTP_HOST']+request.env['REQUEST_PATH']
   end
 
   def get_service(params)
-    log_message = 'GtkApi::get_service'
+    log_message = 'GtkSrv::get_service'
     logger.debug(log_message) {"entered with params #{params}"}
     if params['request_type'] == 'TERMINATE'
       # Get the service_uuid from the creation request

--- a/son-gtkvim/routes/request.rb
+++ b/son-gtkvim/routes/request.rb
@@ -273,7 +273,13 @@ class GtkVim < Sinatra::Base
     halt 500, 'Internal server error'
   end
   end
-
+  
+  get '/began_at/?' do
+    log_message = 'GtkWim /began_at'
+    logger.debug(log_message) {'entered'}
+    logger.debug(log_message) {"began at #{settings.time_at_startup}"}
+    halt 200, {began_at: settings.time_at_startup}.to_json
+  end
 
   get '/admin/logs' do
     logger.debug "GtkSrv: entered GET /admin/logs"


### PR DESCRIPTION
name.

If the micro-service doesn't respond to the '/began_at' endpoint, nil is
returned. This endpoint is to be protected by the rate limiter as well.