### PR TITLE
Fixes small glitches.

### DIFF
--- a/son-gtkapi/models/licence_manager_service.rb
+++ b/son-gtkapi/models/licence_manager_service.rb
@@ -63,7 +63,7 @@ class LicenceManagerService < ManagerService
 
     begin
       self.valid?(params)
-      params[:description] = 'Default description]'
+      params[:description] = 'Default description'
       licence = postCurb(url: @@url+LICENCES_URL, body: params) #, headers: headers)
       GtkApi.logger.debug(method) {"licence=#{licence}"}
       

--- a/son-gtkapi/routes/licences_controller.rb
+++ b/son-gtkapi/routes/licences_controller.rb
@@ -105,6 +105,8 @@ class GtkApi < Sinatra::Base
         halt 201, licence.to_json
       when 400
         json_error 400, '{}', 'Bad request'
+      when 409
+        json_error 409, "Licence #{params} already exists", 'Conflict'
       when 422
         json_error 422, '{}', 'Unprocessable entity'
       else


### PR DESCRIPTION
Default licence description had a ']' and 409 was being treated as a
500.